### PR TITLE
fix: improve release-plz workflow to prevent premature releases

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -6,27 +6,6 @@ on:
       - develop
 
 jobs:
-  release-plz-release:
-    name: Release-plz release
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-      - name: Run release-plz
-        uses: release-plz/action@v0.5
-        with:
-          command: release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   release-plz-pr:
     name: Release-plz PR
     runs-on: ubuntu-latest
@@ -44,9 +23,42 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+      - name: Close old release PRs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          release_prs=$(gh pr list --state open --json number,headRefName --jq '.[] | select(.headRefName | startswith("release-plz-")) | .number')
+          if [[ -n "$release_prs" ]]; then
+            echo "Closing old release PRs: $release_prs"
+            echo "$release_prs" | xargs -I {} gh pr close {}
+          else
+            echo "No open release PRs to close"
+          fi
       - name: Run release-plz
         uses: release-plz/action@v0.5
         with:
           command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  release-plz-release:
+    name: Release-plz release
+    runs-on: ubuntu-latest
+    # Only run when release PR is merged (branch name starts with release-plz-)
+    if: github.event_name == 'push' && startsWith(github.event.head_commit.message, 'Merge pull request') && contains(github.event.head_commit.message, 'release-plz-')
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -13,13 +13,13 @@ repo_url = "https://github.com/jpalczewski/kajet"
 pr_labels = ["🚀 release"]
 
 [changelog]
-header = """# Changelog\n\nAll notable changes to this project will be documented in this file.\n"""
+header = """# 📝 Changelog\n\nAll notable changes to this project will be documented in this file.\n"""
 body = """
 ## `{{ package }}` - [{{ version }}]{% if release_link %}({{ release_link }}){% endif %} - {{ timestamp | date(format="%Y-%m-%d") }}
 {% for group, commits in commits | group_by(attribute="group") %}
-### {{ group | upper_first }}
+### {{ group }}
 {% for commit in commits %}
-- {% if commit.scope %}*({{ commit.scope }})* {% endif %}{% if commit.breaking %}**BREAKING** {% endif %}{{ commit.message }}
+- {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{% if commit.breaking %}💥 **BREAKING** {% endif %}{{ commit.message }}
 {% endfor %}
 {% endfor %}
 """
@@ -28,11 +28,11 @@ protect_breaking_commits = true
 sort_commits = "newest"
 
 commit_parsers = [
-    { message = "^feat", group = "Added" },
-    { message = "^fix", group = "Fixed" },
-    { message = "^perf", group = "Performance" },
-    { message = "^refactor", group = "Changed" },
-    { message = "^doc", group = "Documentation" },
+    { message = "^feat", group = "✨ Added" },
+    { message = "^fix", group = "🐛 Fixed" },
+    { message = "^perf", group = "⚡ Performance" },
+    { message = "^refactor", group = "♻️ Changed" },
+    { message = "^docs", group = "📚 Documentation" },
     { message = "^test", skip = true },
     { message = "^chore", skip = true },
     { message = "^ci", skip = true },
@@ -41,3 +41,56 @@ commit_parsers = [
 commit_preprocessors = [
     { pattern = "\\(#([0-9]+)\\)", replace = "([#${1}](https://github.com/jpalczewski/kajet/pull/${1}))" },
 ]
+
+# Only create GitHub releases for the main kajet package
+[[package]]
+name = "kajet-parser"
+git_release_enable = false
+git_tag_enable = false
+
+[[package]]
+name = "kajet-core"
+git_release_enable = false
+git_tag_enable = false
+
+[[package]]
+name = "kajet-backend"
+git_release_enable = false
+git_tag_enable = false
+
+[[package]]
+name = "kajet-indexer"
+git_release_enable = false
+git_tag_enable = false
+
+[[package]]
+name = "kajet-mcp"
+git_release_enable = false
+git_tag_enable = false
+
+[[package]]
+name = "kajet-web"
+git_release_enable = false
+git_tag_enable = false
+
+[[package]]
+name = "kajet"
+git_release_enable = true
+git_tag_enable = true
+git_tag_name = "v{{ version }}"
+git_release_name = "📓 kajet v{{ version }}"
+git_release_body = """
+{{ changelog }}
+
+---
+
+{% if remote.contributors %}
+## 👥 Contributors
+
+{% for contributor in remote.contributors %}
+* [@{{ contributor.username }}](https://github.com/{{ contributor.username }})
+{% endfor %}
+
+{% endif %}
+**Full Changelog**: https://github.com/jpalczewski/kajet/compare/{{ previous_version }}...v{{ version }}
+"""


### PR DESCRIPTION
## Summary
- ✅ Auto-close old release PRs before creating new ones
- ✅ Run `release` job **only** after release PR is merged (not on every push)
- ✅ Detect release PR merges via commit message pattern
- 🗑️ Deleted bad `*-v0.2.0` tags (were pointing to wrong commit)

## Problems fixed
1. **Tags created prematurely** — `release` job ran on every push, creating tags before PR merge
2. **Multiple open release PRs** — old PRs weren't closed, blocking updates
3. **Wrong commit tagged** — tags pointed to `chore: release v0.1.0` instead of actual version bump

## How it works now
1. Push to `develop` → `release-plz-pr` job runs
2. Closes any old `release-plz-*` PRs
3. Creates new PR with version bumps + CHANGELOG
4. **You merge the PR**
5. `release-plz-release` job detects merge commit → creates tags + GitHub releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)