### PR TITLE
fix: add pull-requests permission to release-plz & kajet-mcp README

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -48,6 +48,7 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.event.head_commit.message, 'Merge pull request') && contains(github.event.head_commit.message, 'release-plz-')
     permissions:
       contents: write
+      pull-requests: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/crates/mcp/README.md
+++ b/crates/mcp/README.md
@@ -1,0 +1,44 @@
+# kajet-mcp
+
+MCP (Model Context Protocol) server for kajet. Exposes semantic search over Obsidian vaults to AI assistants like Claude via stdio transport.
+
+## Tools
+
+### `search`
+
+Search the vault using hybrid search (vector + full-text).
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `String` | The search query |
+| `limit` | `Option<usize>` | Max results (default from config) |
+| `mode` | `Option<String>` | `"hybrid"` (default), `"vector"`, or `"fts"` |
+
+### `reindex`
+
+Reindex the vault. Without arguments performs a full reindex; with `path` reindexes a single file.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `path` | `Option<String>` | Relative path of a specific file (omit for full reindex) |
+
+### `examine`
+
+Inspect an indexed document: metadata (title, tags, outgoing links, backlinks) and content. Supports fuzzy path matching.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `path` | `String` | Full or partial file path (fuzzy matched) |
+| `content` | `Option<String>` | `"summary"` (default, first 500 chars), `"full"`, or `"slice"` |
+| `offset` | `Option<usize>` | Character offset for slice mode |
+| `length` | `Option<usize>` | Character count for slice mode |
+
+### `index_status`
+
+Get current index status: document count, chunk count, last indexing time. No parameters.
+
+## Integration
+
+- **Transport**: stdio (stdin/stdout) — designed for MCP clients
+- **Events**: broadcasts `QueryEvent` via Tokio channel on each search, enabling real-time dashboard updates over WebSocket
+- **i18n**: all user-facing strings localized via `t!()` macro (English + Polish)


### PR DESCRIPTION
## Summary
- Fix `release-plz release` job failing with 403 Forbidden — added missing `pull-requests: read` permission needed to list PRs associated with a commit
- Add README for `kajet-mcp` crate documenting exposed MCP tools (`search`, `reindex`, `examine`, `index_status`)

## Test plan
- [ ] Merge a release-plz PR into develop and verify `release-plz release` job no longer fails with 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)