### PR TITLE
fix: align changelog header with config and add PR/issue links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog
+# 📝 Changelog
 
 All notable changes to this project will be documented in this file.# 📝 Changelog
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -19,7 +19,7 @@ body = """
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group }}
 {% for commit in commits %}
-- {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{% if commit.breaking %}💥 **BREAKING** {% endif %}{{ commit.message }}
+- {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{% if commit.breaking %}💥 **BREAKING** {% endif %}{{ commit.message }}{%- if commit.links %} ({% for link in commit.links %}[{{link.text}}]({{link.href}}) {% endfor -%}){% endif %}
 {% endfor %}
 {% endfor %}
 """


### PR DESCRIPTION
## Summary
- Fix CHANGELOG.md header mismatch (`# Changelog` vs `# 📝 Changelog`) that caused release-plz to duplicate the header 7 times (once per package)
- Add `commit.links` to changelog body template for automatic PR/issue references in changelog entries

## Test plan
- [ ] Merge a release-plz PR and verify changelog header is not duplicated
- [ ] Verify GitHub release body contains PR links

🤖 Generated with [Claude Code](https://claude.com/claude-code)