### PR TITLE
feat: create_note/edit_note with bugfixes and improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3754,6 +3754,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "kajet-core",
+ "kajet-writer",
  "rmcp",
  "rust-i18n",
  "schemars 1.2.1",
@@ -3791,6 +3792,22 @@ dependencies = [
  "tokio",
  "toml 0.8.23",
  "tracing",
+]
+
+[[package]]
+name = "kajet-writer"
+version = "0.2.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "chrono-tz",
+ "ignore",
+ "kajet-core",
+ "kajet-parser",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "unicode-normalization",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/indexer",
     "crates/mcp",
     "crates/web",
+    "crates/writer",
 ]
 
 [package]

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -25,6 +25,54 @@ impl Default for LoggingConfig {
 
 #[derive(Debug, Clone, Deserialize, serde::Serialize)]
 #[serde(default)]
+pub struct TimestampConfig {
+    pub enabled: bool,
+    pub created_field: String,
+    pub modified_field: String,
+    pub format: String,
+    pub timezone: String,
+}
+
+impl Default for TimestampConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            created_field: "created".into(),
+            modified_field: "modified".into(),
+            format: "iso8601".into(),
+            timezone: "local".into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize, serde::Serialize)]
+#[serde(default)]
+pub struct FrontmatterConfig {
+    pub default_tags: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize, serde::Serialize)]
+#[serde(default)]
+pub struct WriterConfig {
+    pub backup_enabled: bool,
+    pub backup_max_per_file: usize,
+    pub timestamps: TimestampConfig,
+    pub frontmatter: FrontmatterConfig,
+}
+
+impl Default for WriterConfig {
+    fn default() -> Self {
+        Self {
+            backup_enabled: true,
+            backup_max_per_file: 10,
+            timestamps: TimestampConfig::default(),
+            frontmatter: FrontmatterConfig::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, serde::Serialize)]
+#[serde(default)]
 pub struct KajetConfig {
     pub port: u16,
     pub language: String,
@@ -36,6 +84,7 @@ pub struct KajetConfig {
     pub open_browser: bool,
     pub resolve_wikilinks: bool,
     pub logging: LoggingConfig,
+    pub writer: WriterConfig,
 }
 
 impl Default for KajetConfig {
@@ -51,6 +100,7 @@ impl Default for KajetConfig {
             open_browser: false,
             resolve_wikilinks: true,
             logging: LoggingConfig::default(),
+            writer: WriterConfig::default(),
         }
     }
 }
@@ -67,10 +117,11 @@ const GLOBAL_FIELDS: &[&str] = &[
     "open_browser",
     "resolve_wikilinks",
     "logging",
+    "writer",
 ];
 
 /// Fields allowed in vault-level config.
-const VAULT_FIELDS: &[&str] = &["exclude_folders", "embedding_model"];
+const VAULT_FIELDS: &[&str] = &["exclude_folders", "embedding_model", "writer"];
 
 /// Load config with layered priority: defaults < global < per-vault < env < CLI.
 ///
@@ -100,7 +151,15 @@ pub fn load_config(
         .set_default("logging.level", "debug")?
         .set_default("logging.file_level", "trace")?
         .set_default("logging.dashboard_level", "info")?
-        .set_default("logging.progress_percent_step", 5_i64)?;
+        .set_default("logging.progress_percent_step", 5_i64)?
+        .set_default("writer.backup_enabled", true)?
+        .set_default("writer.backup_max_per_file", 10_i64)?
+        .set_default("writer.timestamps.enabled", true)?
+        .set_default("writer.timestamps.created_field", "created")?
+        .set_default("writer.timestamps.modified_field", "modified")?
+        .set_default("writer.timestamps.format", "iso8601")?
+        .set_default("writer.timestamps.timezone", "local")?
+        .set_default::<&str, Vec<String>>("writer.frontmatter.default_tags", vec![])?;
 
     // 2. Global config: ~/.config/kajet/config.toml
     if let Some(config_dir) = dirs::config_dir() {
@@ -389,6 +448,100 @@ mod tests {
         assert_eq!(logging["level"].as_str(), Some("debug"));
         assert_eq!(logging["file_level"].as_str(), Some("trace"));
         assert_eq!(logging["dashboard_level"].as_str(), Some("error"));
+    }
+
+    #[test]
+    fn writer_config_defaults() {
+        let config = KajetConfig::default();
+        assert!(config.writer.backup_enabled);
+        assert_eq!(config.writer.backup_max_per_file, 10);
+        assert!(config.writer.timestamps.enabled);
+        assert_eq!(config.writer.timestamps.created_field, "created");
+        assert_eq!(config.writer.timestamps.modified_field, "modified");
+        assert_eq!(config.writer.timestamps.format, "iso8601");
+        assert_eq!(config.writer.timestamps.timezone, "local");
+        assert!(config.writer.frontmatter.default_tags.is_empty());
+    }
+
+    #[test]
+    fn writer_config_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+
+        let mut ts = toml::Table::new();
+        ts.insert("enabled".into(), toml::Value::Boolean(false));
+        ts.insert(
+            "created_field".into(),
+            toml::Value::String("date_created".into()),
+        );
+        ts.insert("format".into(), toml::Value::String("date_only".into()));
+        ts.insert(
+            "timezone".into(),
+            toml::Value::String("Europe/Warsaw".into()),
+        );
+
+        let mut fm = toml::Table::new();
+        fm.insert(
+            "default_tags".into(),
+            toml::Value::Array(vec![toml::Value::String("kajet".into())]),
+        );
+
+        let mut writer = toml::Table::new();
+        writer.insert("backup_enabled".into(), toml::Value::Boolean(false));
+        writer.insert("backup_max_per_file".into(), toml::Value::Integer(5));
+        writer.insert("timestamps".into(), toml::Value::Table(ts));
+        writer.insert("frontmatter".into(), toml::Value::Table(fm));
+
+        let mut updates = HashMap::new();
+        updates.insert("writer".into(), toml::Value::Table(writer));
+        write_toml_config(&path, &updates).unwrap();
+
+        let content = fs::read_to_string(&path).unwrap();
+        let table: toml::Table = content.parse().unwrap();
+        let w = table["writer"].as_table().unwrap();
+        assert_eq!(w["backup_enabled"].as_bool(), Some(false));
+        assert_eq!(w["backup_max_per_file"].as_integer(), Some(5));
+        let ts = w["timestamps"].as_table().unwrap();
+        assert_eq!(ts["enabled"].as_bool(), Some(false));
+        assert_eq!(ts["format"].as_str(), Some("date_only"));
+        assert_eq!(ts["timezone"].as_str(), Some("Europe/Warsaw"));
+        let fm = w["frontmatter"].as_table().unwrap();
+        let tags = fm["default_tags"].as_array().unwrap();
+        assert_eq!(tags[0].as_str(), Some("kajet"));
+    }
+
+    #[test]
+    fn writer_config_deep_merge() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+
+        // Write initial writer config
+        let mut ts = toml::Table::new();
+        ts.insert("enabled".into(), toml::Value::Boolean(true));
+        ts.insert("format".into(), toml::Value::String("iso8601".into()));
+        let mut writer = toml::Table::new();
+        writer.insert("backup_enabled".into(), toml::Value::Boolean(true));
+        writer.insert("timestamps".into(), toml::Value::Table(ts));
+        let mut updates = HashMap::new();
+        updates.insert("writer".into(), toml::Value::Table(writer));
+        write_toml_config(&path, &updates).unwrap();
+
+        // Update only backup_enabled — timestamps should survive
+        let mut writer_update = toml::Table::new();
+        writer_update.insert("backup_enabled".into(), toml::Value::Boolean(false));
+        let mut updates2 = HashMap::new();
+        updates2.insert("writer".into(), toml::Value::Table(writer_update));
+        write_toml_config(&path, &updates2).unwrap();
+
+        let content = fs::read_to_string(&path).unwrap();
+        let table: toml::Table = content.parse().unwrap();
+        let w = table["writer"].as_table().unwrap();
+        assert_eq!(w["backup_enabled"].as_bool(), Some(false));
+        // timestamps sub-table should be preserved
+        assert!(w.contains_key("timestamps"));
+        let ts = w["timestamps"].as_table().unwrap();
+        assert_eq!(ts["enabled"].as_bool(), Some(true));
+        assert_eq!(ts["format"].as_str(), Some("iso8601"));
     }
 
     #[test]

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 kajet-core = { path = "../core" }
+kajet-writer = { path = "../writer" }
 
 rmcp = { version = "0.14", features = ["server", "transport-io"] }
 schemars = "1.2"

--- a/crates/mcp/src/format.rs
+++ b/crates/mcp/src/format.rs
@@ -1,5 +1,6 @@
 use kajet_core::search::SearchResult;
 use kajet_core::types::Document;
+use kajet_writer::{CreateNoteResult, EditNoteResult};
 
 pub fn format_results(query: &str, results: &[SearchResult]) -> String {
     if results.is_empty() {
@@ -188,12 +189,83 @@ pub fn format_list_tags(
     format!("{header}\n{body}")
 }
 
+pub fn format_create_result(result: &CreateNoteResult) -> String {
+    t!(
+        "create_note_success",
+        path = &result.path,
+        bytes = result.bytes_written
+    )
+    .to_string()
+}
+
+pub fn format_edit_result(result: &EditNoteResult) -> String {
+    let mut text = t!(
+        "edit_note_success",
+        path = &result.path,
+        mode = &result.mode,
+        bytes = result.bytes_written
+    )
+    .to_string();
+
+    if result.backup_path.is_some() {
+        text.push_str(&format!("\n{}", t!("edit_note_backup_created")));
+    }
+
+    text
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     fn setup_locale() {
         rust_i18n::set_locale("en");
+    }
+
+    #[test]
+    fn format_create_result_basic() {
+        setup_locale();
+        let result = CreateNoteResult {
+            path: "test/note.md".into(),
+            absolute_path: "/vault/test/note.md".into(),
+            bytes_written: 256,
+        };
+        let text = format_create_result(&result);
+        assert!(text.contains("test/note.md"));
+        assert!(text.contains("256"));
+    }
+
+    #[test]
+    fn format_edit_result_basic() {
+        setup_locale();
+        let result = EditNoteResult {
+            path: "note.md".into(),
+            absolute_path: "/vault/note.md".into(),
+            mode: "append".into(),
+            bytes_written: 128,
+            backup_path: None,
+        };
+        let text = format_edit_result(&result);
+        assert!(text.contains("note.md"));
+        assert!(text.contains("append"));
+        assert!(text.contains("128"));
+        assert!(!text.contains("Backup"));
+    }
+
+    #[test]
+    fn format_edit_result_with_backup() {
+        setup_locale();
+        let result = EditNoteResult {
+            path: "note.md".into(),
+            absolute_path: "/vault/note.md".into(),
+            mode: "overwrite".into(),
+            bytes_written: 512,
+            backup_path: Some("/vault/.kajet/backups/20260208T120000_note.md".into()),
+        };
+        let text = format_edit_result(&result);
+        assert!(text.contains("note.md"));
+        assert!(text.contains("overwrite"));
+        assert!(text.contains("Backup"));
     }
 
     #[test]

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -7,8 +7,14 @@ mod format;
 mod schema;
 mod tools;
 
-pub use format::{format_examine_result, format_list_tags, format_results};
-pub use schema::{ExamineRequest, ListTagsRequest, ReindexRequest, SearchRequest};
+pub use format::{
+    format_create_result, format_edit_result, format_examine_result, format_list_tags,
+    format_results,
+};
+pub use schema::{
+    CreateNoteRequest, EditNoteRequest, ExamineRequest, ListTagsRequest, ReindexRequest,
+    SearchRequest,
+};
 
 use anyhow::Result;
 use kajet_core::types::AppState;

--- a/crates/mcp/src/schema.rs
+++ b/crates/mcp/src/schema.rs
@@ -50,6 +50,60 @@ pub struct SearchRequest {
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct CreateNoteRequest {
+    /// Relative path for the new note, e.g. "Projects/ideas.md". Parent directories are created automatically.
+    #[schemars(
+        description = "Relative path for the new note, e.g. 'Projects/ideas.md'. The .md extension is added if missing."
+    )]
+    pub target: String,
+
+    /// Markdown body content for the note
+    #[schemars(description = "Markdown body content for the note")]
+    pub content: String,
+
+    /// Tags to include in the note's frontmatter
+    #[schemars(description = "Tags to include in the note's frontmatter")]
+    pub tags: Option<Vec<String>>,
+
+    /// Aliases for the note (alternative names used by Obsidian for linking)
+    #[schemars(
+        description = "Aliases for the note (alternative names used by Obsidian for linking)"
+    )]
+    pub aliases: Option<Vec<String>>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct EditNoteRequest {
+    /// Path to the note (full, partial, or filename — fuzzy suffix matching is used)
+    #[schemars(
+        description = "Path to the note — full relative path or partial (filename). Fuzzy suffix matching resolves partial paths."
+    )]
+    pub path: String,
+
+    /// New content to insert or replace with
+    #[schemars(description = "New content to insert or replace with")]
+    pub content: String,
+
+    /// Edit mode: 'append', 'prepend', 'overwrite', 'replace_section', 'replace_text', 'insert_after'
+    #[schemars(
+        description = "Edit mode: 'append' (add to end), 'prepend' (add after frontmatter), 'overwrite' (replace body), 'replace_section' (replace heading section), 'replace_text' (exact string replacement), 'insert_after' (insert content after exact text anchor — use old_text as anchor)"
+    )]
+    pub mode: String,
+
+    /// Target heading for section-level operations. Required for replace_section, optional for append/prepend.
+    #[schemars(
+        description = "Target heading for section-level operations (e.g. '## Tasks'). Required for replace_section, optional for append/prepend."
+    )]
+    pub target_heading: Option<String>,
+
+    /// Old text to replace or anchor (required for replace_text and insert_after modes)
+    #[schemars(
+        description = "The exact text to find and replace (required for replace_text mode) or anchor to insert after (required for insert_after mode)"
+    )]
+    pub old_text: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct ListTagsRequest {
     /// Filter by folder path prefix, e.g. 'journal/2025'
     #[schemars(description = "Filter by folder path prefix, e.g. 'journal/2025'")]

--- a/crates/mcp/src/tools.rs
+++ b/crates/mcp/src/tools.rs
@@ -1,5 +1,11 @@
-use crate::format::{format_examine_result, format_list_tags, format_results};
-use crate::schema::{ExamineRequest, ListTagsRequest, ReindexRequest, SearchRequest};
+use crate::format::{
+    format_create_result, format_edit_result, format_examine_result, format_list_tags,
+    format_results,
+};
+use crate::schema::{
+    CreateNoteRequest, EditNoteRequest, ExamineRequest, ListTagsRequest, ReindexRequest,
+    SearchRequest,
+};
 use kajet_core::types::QueryEvent;
 use rmcp::{handler::server::wrapper::Parameters, model::*, tool, tool_router};
 use std::collections::HashMap;
@@ -176,6 +182,114 @@ impl crate::KajetMcp {
         );
 
         Ok(CallToolResult::success(vec![Content::text(text)]))
+    }
+
+    #[tool(
+        description = "Create a new note in the Obsidian vault. Generates frontmatter with title, tags, and timestamps automatically. Fails if file already exists."
+    )]
+    #[instrument(level = "debug", skip(self, params), fields(target))]
+    async fn create_note(
+        &self,
+        params: Parameters<CreateNoteRequest>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let req = params.0;
+        let span = tracing::Span::current();
+        span.record("target", req.target.as_str());
+
+        let config = self.state.config.read().unwrap().writer.clone();
+        let vault_path = std::path::PathBuf::from(&self.state.vault_path);
+        let doc_store = self.state.search_engine.doc_store().clone();
+
+        let writer = kajet_writer::NoteWriter::new(
+            vault_path,
+            self.state.db_path.clone(),
+            config,
+            Some(doc_store),
+        );
+
+        let result = writer
+            .create(kajet_writer::CreateNoteParams {
+                target: req.target,
+                content: req.content,
+                tags: req.tags.unwrap_or_default(),
+                aliases: req.aliases.unwrap_or_default(),
+            })
+            .await
+            .map_err(|e| {
+                internal_error(t!("create_note_failed", error = e.to_string()).to_string())
+            })?;
+
+        // Reindex the newly created file
+        let vault = std::path::Path::new(&self.state.vault_path);
+        if let Err(e) = self
+            .state
+            .indexer
+            .reindex_files(vault, std::slice::from_ref(&result.path))
+            .await
+        {
+            tracing::warn!(path = %result.path, error = %e, "Failed to reindex after create");
+        }
+
+        Ok(CallToolResult::success(vec![Content::text(
+            format_create_result(&result),
+        )]))
+    }
+
+    #[tool(
+        description = "Edit an existing note in the Obsidian vault. Modes: 'append' (add to end), 'prepend' (add after frontmatter), 'overwrite' (replace body), 'replace_section' (replace heading section), 'replace_text' (exact string replacement), 'insert_after' (insert content after exact text anchor, uses old_text as anchor). Backups are created for destructive operations."
+    )]
+    #[instrument(level = "debug", skip(self, params), fields(path, mode))]
+    async fn edit_note(
+        &self,
+        params: Parameters<EditNoteRequest>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let req = params.0;
+        let span = tracing::Span::current();
+        span.record("path", req.path.as_str());
+        span.record("mode", req.mode.as_str());
+
+        let mode: kajet_writer::EditMode = req.mode.parse().map_err(|_| {
+            internal_error(t!("edit_note_invalid_mode", mode = &req.mode).to_string())
+        })?;
+
+        let config = self.state.config.read().unwrap().writer.clone();
+        let vault_path = std::path::PathBuf::from(&self.state.vault_path);
+        let doc_store = self.state.search_engine.doc_store().clone();
+
+        let writer = kajet_writer::NoteWriter::new(
+            vault_path,
+            self.state.db_path.clone(),
+            config,
+            Some(doc_store),
+        );
+
+        let result = writer
+            .edit(kajet_writer::EditNoteParams {
+                path: req.path,
+                content: req.content,
+                mode,
+                target_heading: req.target_heading,
+                old_text: req.old_text,
+            })
+            .await
+            .map_err(|e| {
+                internal_error(t!("edit_note_failed", error = e.to_string()).to_string())
+            })?;
+
+        // Reindex the edited file
+        let vault = std::path::Path::new(&self.state.vault_path);
+        if let Err(e) = self
+            .state
+            .indexer
+            .reindex_files(vault, std::slice::from_ref(&result.path))
+            .await
+        {
+            tracing::warn!(path = %result.path, error = %e, "Failed to reindex after edit");
+        }
+
+        Ok(CallToolResult::success(vec![Content::text(
+            format_edit_result(&result),
+        )]))
     }
 
     #[tool(

--- a/crates/parser/src/frontmatter.rs
+++ b/crates/parser/src/frontmatter.rs
@@ -150,11 +150,15 @@ pub fn update_frontmatter_field(content: &str, field: &str, value: &str) -> Stri
 
     // Frontmatter body: between "---\n" and "\n---"
     let fm_start = if content[3..].starts_with('\n') { 4 } else { 3 };
-    let fm_body = &content[fm_start..closing_offset];
-
-    // Everything after the closing "---" (including its trailing newline if present)
     let after_closing = closing_offset + 4; // skip "\n---"
     let after_fm = &content[after_closing..];
+
+    // Empty frontmatter (e.g. "---\n---")
+    if fm_start > closing_offset {
+        return format!("---\n{field}: {value}\n---{after_fm}");
+    }
+
+    let fm_body = &content[fm_start..closing_offset];
 
     // Check if field already exists
     let field_prefix = format!("{field}:");
@@ -192,9 +196,15 @@ pub fn update_existing_frontmatter_field(content: &str, field: &str, value: &str
     };
 
     let fm_start = if content[3..].starts_with('\n') { 4 } else { 3 };
-    let fm_body = &content[fm_start..closing_offset];
     let after_closing = closing_offset + 4;
     let after_fm = &content[after_closing..];
+
+    // Empty frontmatter — field can't exist, nothing to update
+    if fm_start > closing_offset {
+        return content.to_string();
+    }
+
+    let fm_body = &content[fm_start..closing_offset];
 
     let field_prefix = format!("{field}:");
     let mut new_fm_lines: Vec<String> = Vec::new();
@@ -430,6 +440,21 @@ mod tests {
     #[test]
     fn update_existing_no_frontmatter_unchanged() {
         let content = "# Body\n\nText here.\n";
+        let result = update_existing_frontmatter_field(content, "modified", "2026-02-08");
+        assert_eq!(result, content);
+    }
+
+    #[test]
+    fn update_empty_frontmatter() {
+        let content = "---\n---\n# Body\n";
+        let result = update_frontmatter_field(content, "modified", "2026-02-08");
+        assert!(result.contains("modified: 2026-02-08"));
+        assert!(result.contains("# Body"));
+    }
+
+    #[test]
+    fn update_existing_empty_frontmatter_unchanged() {
+        let content = "---\n---\n# Body\n";
         let result = update_existing_frontmatter_field(content, "modified", "2026-02-08");
         assert_eq!(result, content);
     }

--- a/crates/parser/src/frontmatter.rs
+++ b/crates/parser/src/frontmatter.rs
@@ -80,6 +80,141 @@ pub fn extract_tags(frontmatter: &str) -> Vec<String> {
     tags
 }
 
+/// Generate YAML frontmatter for a new note.
+pub fn generate_frontmatter(
+    title: &str,
+    tags: &[String],
+    default_tags: &[String],
+    aliases: &[String],
+    timestamp: Option<&str>,
+    created_field: &str,
+    modified_field: &str,
+) -> String {
+    let mut lines = vec!["---".to_string()];
+
+    // Title — escape quotes
+    let escaped_title = title.replace('"', "\\\"");
+    lines.push(format!("title: \"{escaped_title}\""));
+
+    // Aliases
+    if !aliases.is_empty() {
+        let formatted: Vec<String> = aliases.iter().map(|a| a.to_string()).collect();
+        lines.push(format!("aliases: [{}]", formatted.join(", ")));
+    }
+
+    // Merge user tags + default_tags (deduped, preserving order)
+    let mut all_tags: Vec<&str> = tags.iter().map(|s| s.as_str()).collect();
+    for dt in default_tags {
+        if !all_tags.contains(&dt.as_str()) {
+            all_tags.push(dt.as_str());
+        }
+    }
+    if !all_tags.is_empty() {
+        let formatted: Vec<String> = all_tags.iter().map(|t| t.to_string()).collect();
+        lines.push(format!("tags: [{}]", formatted.join(", ")));
+    }
+
+    // Timestamps
+    if let Some(ts) = timestamp {
+        if !created_field.is_empty() {
+            lines.push(format!("{created_field}: {ts}"));
+        }
+        if !modified_field.is_empty() {
+            lines.push(format!("{modified_field}: {ts}"));
+        }
+    }
+
+    lines.push("---".to_string());
+    lines.join("\n") + "\n"
+}
+
+/// Update or add a field in existing frontmatter.
+///
+/// - If the field exists: replaces the value.
+/// - If the field is missing but frontmatter exists: adds before closing `---`.
+/// - If no frontmatter: creates one with just this field.
+pub fn update_frontmatter_field(content: &str, field: &str, value: &str) -> String {
+    if !content.starts_with("---") {
+        // No frontmatter — create minimal one
+        return format!("---\n{field}: {value}\n---\n{content}");
+    }
+
+    // Find closing \n--- after the opening ---
+    let search_start = 3; // skip opening "---"
+    let closing_offset = match content[search_start..].find("\n---") {
+        Some(pos) => search_start + pos, // absolute position of \n in "\n---"
+        None => {
+            return format!("---\n{field}: {value}\n---\n{content}");
+        }
+    };
+
+    // Frontmatter body: between "---\n" and "\n---"
+    let fm_start = if content[3..].starts_with('\n') { 4 } else { 3 };
+    let fm_body = &content[fm_start..closing_offset];
+
+    // Everything after the closing "---" (including its trailing newline if present)
+    let after_closing = closing_offset + 4; // skip "\n---"
+    let after_fm = &content[after_closing..];
+
+    // Check if field already exists
+    let field_prefix = format!("{field}:");
+    let mut new_fm_lines: Vec<String> = Vec::new();
+    let mut found = false;
+    for line in fm_body.lines() {
+        if line.trim_start().starts_with(&field_prefix) {
+            new_fm_lines.push(format!("{field}: {value}"));
+            found = true;
+        } else {
+            new_fm_lines.push(line.to_string());
+        }
+    }
+    if !found {
+        new_fm_lines.push(format!("{field}: {value}"));
+    }
+
+    format!("---\n{}\n---{after_fm}", new_fm_lines.join("\n"))
+}
+
+/// Update a field in existing frontmatter — only if it already exists.
+///
+/// Returns content unchanged if the field is not found or no frontmatter exists.
+/// Use this for edit operations to avoid adding duplicate timestamp fields
+/// when the note was created by a different tool (e.g. Obsidian).
+pub fn update_existing_frontmatter_field(content: &str, field: &str, value: &str) -> String {
+    if !content.starts_with("---") {
+        return content.to_string();
+    }
+
+    let search_start = 3;
+    let closing_offset = match content[search_start..].find("\n---") {
+        Some(pos) => search_start + pos,
+        None => return content.to_string(),
+    };
+
+    let fm_start = if content[3..].starts_with('\n') { 4 } else { 3 };
+    let fm_body = &content[fm_start..closing_offset];
+    let after_closing = closing_offset + 4;
+    let after_fm = &content[after_closing..];
+
+    let field_prefix = format!("{field}:");
+    let mut new_fm_lines: Vec<String> = Vec::new();
+    let mut found = false;
+    for line in fm_body.lines() {
+        if line.trim_start().starts_with(&field_prefix) {
+            new_fm_lines.push(format!("{field}: {value}"));
+            found = true;
+        } else {
+            new_fm_lines.push(line.to_string());
+        }
+    }
+
+    if !found {
+        return content.to_string();
+    }
+
+    format!("---\n{}\n---{after_fm}", new_fm_lines.join("\n"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -130,5 +265,172 @@ mod tests {
     #[test]
     fn extract_tags_empty() {
         assert!(extract_tags("").is_empty());
+    }
+
+    // -- generate_frontmatter tests --
+
+    #[test]
+    fn generate_frontmatter_basic() {
+        let result = generate_frontmatter(
+            "My Note",
+            &["rust".into(), "test".into()],
+            &[],
+            &[],
+            Some("2026-02-08T12:00:00"),
+            "created",
+            "modified",
+        );
+        assert!(result.starts_with("---\n"));
+        assert!(result.ends_with("---\n"));
+        assert!(result.contains("title: \"My Note\""));
+        assert!(result.contains("tags: [rust, test]"));
+        assert!(result.contains("created: 2026-02-08T12:00:00"));
+        assert!(result.contains("modified: 2026-02-08T12:00:00"));
+    }
+
+    #[test]
+    fn generate_frontmatter_merge_default_tags() {
+        let result = generate_frontmatter(
+            "Note",
+            &["rust".into()],
+            &["kajet".into(), "rust".into()], // rust already in user tags
+            &[],
+            None,
+            "created",
+            "modified",
+        );
+        assert!(result.contains("tags: [rust, kajet]"));
+        // No duplicates: "rust" appears only once
+        let tag_count = result.matches("rust").count();
+        assert_eq!(tag_count, 1);
+    }
+
+    #[test]
+    fn generate_frontmatter_no_tags_no_timestamp() {
+        let result = generate_frontmatter("Note", &[], &[], &[], None, "created", "modified");
+        assert!(result.contains("title: \"Note\""));
+        assert!(!result.contains("tags:"));
+        assert!(!result.contains("created:"));
+        assert!(!result.contains("modified:"));
+    }
+
+    #[test]
+    fn generate_frontmatter_escapes_quotes() {
+        let result = generate_frontmatter(
+            "Note \"with\" quotes",
+            &[],
+            &[],
+            &[],
+            None,
+            "created",
+            "modified",
+        );
+        assert!(result.contains("title: \"Note \\\"with\\\" quotes\""));
+    }
+
+    #[test]
+    fn generate_frontmatter_with_aliases() {
+        let result = generate_frontmatter(
+            "My Note",
+            &["rust".into()],
+            &[],
+            &["alias1".into(), "alias2".into()],
+            None,
+            "created",
+            "modified",
+        );
+        assert!(result.contains("aliases: [alias1, alias2]"));
+    }
+
+    #[test]
+    fn generate_frontmatter_without_aliases() {
+        let result = generate_frontmatter("My Note", &[], &[], &[], None, "created", "modified");
+        assert!(!result.contains("aliases:"));
+    }
+
+    #[test]
+    fn generate_frontmatter_empty_created_field() {
+        let result =
+            generate_frontmatter("Note", &[], &[], &[], Some("2026-02-08"), "", "modified");
+        assert!(!result.contains("created:"));
+        // Note: we don't search for a bare empty field name
+        assert!(result.contains("modified: 2026-02-08"));
+    }
+
+    #[test]
+    fn generate_frontmatter_both_fields_empty() {
+        let result = generate_frontmatter("Note", &[], &[], &[], Some("2026-02-08"), "", "");
+        assert!(!result.contains("2026-02-08"));
+    }
+
+    // -- update_frontmatter_field tests --
+
+    #[test]
+    fn update_existing_field() {
+        let content = "---\ntitle: \"Old\"\nmodified: 2025-01-01\n---\n# Body\n";
+        let result = update_frontmatter_field(content, "modified", "2026-02-08");
+        assert!(result.contains("modified: 2026-02-08"));
+        assert!(!result.contains("2025-01-01"));
+        assert!(result.contains("# Body"));
+    }
+
+    #[test]
+    fn update_add_new_field() {
+        let content = "---\ntitle: \"Note\"\n---\n# Body\n";
+        let result = update_frontmatter_field(content, "modified", "2026-02-08");
+        assert!(result.contains("modified: 2026-02-08"));
+        assert!(result.contains("title: \"Note\""));
+        assert!(result.contains("# Body"));
+    }
+
+    #[test]
+    fn update_no_frontmatter() {
+        let content = "# Body\n\nText here.\n";
+        let result = update_frontmatter_field(content, "modified", "2026-02-08");
+        assert!(result.starts_with("---\n"));
+        assert!(result.contains("modified: 2026-02-08"));
+        assert!(result.contains("# Body"));
+    }
+
+    #[test]
+    fn update_preserves_body_with_wikilinks() {
+        let content = "---\ntags: [test]\n---\n# Współpraca\n\nSee [[Link]] and [[Other|alias]].\n";
+        let result = update_frontmatter_field(content, "modified", "2026-02-08");
+        assert!(result.contains("[[Link]]"));
+        assert!(result.contains("[[Other|alias]]"));
+        assert!(result.contains("Współpraca"));
+    }
+
+    // -- update_existing_frontmatter_field tests --
+
+    #[test]
+    fn update_existing_only_updates_present_field() {
+        let content = "---\ntitle: \"Note\"\nmodified: 2025-01-01\n---\n# Body\n";
+        let result = update_existing_frontmatter_field(content, "modified", "2026-02-08");
+        assert!(result.contains("modified: 2026-02-08"));
+        assert!(!result.contains("2025-01-01"));
+    }
+
+    #[test]
+    fn update_existing_skips_missing_field() {
+        // Note created by Obsidian with Polish field names — kajet should NOT add "modified:"
+        let content = "---\ntitle: \"Note\"\nData aktualizacji: 2025-01-01\n---\n# Body\n";
+        let result = update_existing_frontmatter_field(content, "modified", "2026-02-08");
+        assert!(
+            !result.contains("modified:"),
+            "Should not add missing field"
+        );
+        assert!(
+            result.contains("Data aktualizacji: 2025-01-01"),
+            "Original field preserved"
+        );
+        assert_eq!(result, content);
+    }
+
+    #[test]
+    fn update_existing_no_frontmatter_unchanged() {
+        let content = "# Body\n\nText here.\n";
+        let result = update_existing_frontmatter_field(content, "modified", "2026-02-08");
+        assert_eq!(result, content);
     }
 }

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -1,12 +1,22 @@
 mod chunker;
 mod frontmatter;
+pub mod sections;
+pub mod transforms;
 pub mod types;
 pub mod vault;
 pub mod wikilinks;
 
 // Re-export public API
 pub use chunker::{chunk_markdown, heading_level_to_u8};
-pub use frontmatter::{extract_tags, extract_title, strip_frontmatter};
+pub use frontmatter::{
+    extract_tags, extract_title, generate_frontmatter, strip_frontmatter,
+    update_existing_frontmatter_field, update_frontmatter_field,
+};
+pub use sections::{find_section_by_heading, parse_sections, Section, SectionLookupError};
+pub use transforms::{
+    append_content, insert_after, overwrite_body, prepend_content, replace_section, replace_text,
+    MatchPosition, ReplaceError, TransformError,
+};
 pub use types::{Chunk, ChunkConfig, Link, ParsedDocument};
 pub use vault::{parse_vault, parse_vault_entries, parse_vault_entries_with_config, scan_vault};
 pub use wikilinks::{extract_wikilinks, resolve_wikilinks_in_text};

--- a/crates/parser/src/sections.rs
+++ b/crates/parser/src/sections.rs
@@ -1,0 +1,294 @@
+use crate::chunker::heading_level_to_u8;
+use pulldown_cmark::{Event, Options, Parser, Tag, TagEnd};
+use std::ops::Range;
+
+/// A section of a markdown document, defined by its heading.
+#[derive(Debug, Clone)]
+pub struct Section {
+    /// Heading level (1–6).
+    pub level: u8,
+    /// The text content of the heading (without `#` markers).
+    pub heading_text: String,
+    /// Byte range of the full heading line(s) in the source markdown.
+    pub heading_range: Range<usize>,
+    /// Byte range of the body (content between this heading and the next same-or-higher-level heading, or EOF).
+    pub body_range: Range<usize>,
+}
+
+/// Errors from `find_section_by_heading`.
+#[derive(Debug, Clone)]
+pub enum SectionLookupError {
+    NotFound { available: Vec<String> },
+    Ambiguous { count: usize },
+}
+
+impl std::fmt::Display for SectionLookupError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound { available } => {
+                write!(f, "Heading not found. Available: {}", available.join(", "))
+            }
+            Self::Ambiguous { count } => {
+                write!(f, "Heading is ambiguous: {count} matches found")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SectionLookupError {}
+
+/// Parse all sections from a markdown document.
+///
+/// Returns sections with byte-accurate ranges for both heading and body.
+/// Headings inside fenced code blocks are ignored.
+pub fn parse_sections(markdown: &str) -> Vec<Section> {
+    let parser = Parser::new_ext(markdown, Options::empty()).into_offset_iter();
+
+    let mut sections = Vec::new();
+    let mut in_heading = false;
+    let mut heading_text = String::new();
+    let mut heading_start: usize = 0;
+    let mut heading_level: u8 = 0;
+    let mut in_code_block = false;
+
+    for (event, range) in parser {
+        match event {
+            Event::Start(Tag::CodeBlock(_)) => {
+                in_code_block = true;
+            }
+            Event::End(TagEnd::CodeBlock) => {
+                in_code_block = false;
+            }
+            Event::Start(Tag::Heading { level, .. }) if !in_code_block => {
+                in_heading = true;
+                heading_text.clear();
+                heading_start = range.start;
+                heading_level = heading_level_to_u8(level);
+            }
+            Event::End(TagEnd::Heading(_)) if !in_code_block => {
+                in_heading = false;
+                sections.push(Section {
+                    level: heading_level,
+                    heading_text: heading_text.clone(),
+                    heading_range: heading_start..range.end,
+                    body_range: range.end..range.end, // placeholder, computed below
+                });
+            }
+            Event::Text(text) | Event::Code(text) if in_heading => {
+                heading_text.push_str(&text);
+            }
+            _ => {}
+        }
+    }
+
+    compute_body_ranges(&mut sections, markdown.len());
+    sections
+}
+
+/// Compute body ranges: each section's body runs from after its heading
+/// to the start of the next same-or-higher-level heading (or EOF).
+fn compute_body_ranges(sections: &mut [Section], doc_len: usize) {
+    for i in 0..sections.len() {
+        let body_start = sections[i].heading_range.end;
+        let body_end = sections[i + 1..]
+            .iter()
+            .find(|s| s.level <= sections[i].level)
+            .map(|s| s.heading_range.start)
+            .unwrap_or(doc_len);
+        sections[i].body_range = body_start..body_end;
+    }
+}
+
+/// Find a section by its heading text.
+///
+/// Accepts headings with or without `#` prefix (e.g. both `"Tasks"` and `"## Tasks"` match).
+/// Returns an error if no match or multiple matches are found.
+pub fn find_section_by_heading<'a>(
+    sections: &'a [Section],
+    heading: &str,
+) -> Result<&'a Section, SectionLookupError> {
+    // Strip leading `#` markers and whitespace
+    let needle = heading.trim_start_matches('#').trim();
+
+    let matches: Vec<&Section> = sections
+        .iter()
+        .filter(|s| s.heading_text.trim() == needle)
+        .collect();
+
+    match matches.len() {
+        0 => Err(SectionLookupError::NotFound {
+            available: sections.iter().map(|s| s.heading_text.clone()).collect(),
+        }),
+        1 => Ok(matches[0]),
+        n => Err(SectionLookupError::Ambiguous { count: n }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_document() {
+        let sections = parse_sections("");
+        assert!(sections.is_empty());
+    }
+
+    #[test]
+    fn no_headings() {
+        let sections = parse_sections("Just some plain text without any headings.");
+        assert!(sections.is_empty());
+    }
+
+    #[test]
+    fn single_heading() {
+        let md = "# Title\n\nSome body text.\n";
+        let sections = parse_sections(md);
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].level, 1);
+        assert_eq!(sections[0].heading_text, "Title");
+        assert_eq!(&md[sections[0].heading_range.clone()], "# Title\n");
+        assert_eq!(md[sections[0].body_range.clone()].trim(), "Some body text.");
+    }
+
+    #[test]
+    fn sibling_headings() {
+        let md = "# First\n\nBody 1\n\n# Second\n\nBody 2\n";
+        let sections = parse_sections(md);
+        assert_eq!(sections.len(), 2);
+        assert_eq!(sections[0].heading_text, "First");
+        assert_eq!(sections[1].heading_text, "Second");
+        // First section body ends at second heading
+        assert!(md[sections[0].body_range.clone()].contains("Body 1"));
+        assert!(!md[sections[0].body_range.clone()].contains("Body 2"));
+        // Second section body to EOF
+        assert!(md[sections[1].body_range.clone()].contains("Body 2"));
+    }
+
+    #[test]
+    fn nested_headings() {
+        let md = "# H1\n\nH1 body\n\n## H2\n\nH2 body\n\n### H3\n\nH3 body\n";
+        let sections = parse_sections(md);
+        assert_eq!(sections.len(), 3);
+        assert_eq!(sections[0].level, 1);
+        assert_eq!(sections[1].level, 2);
+        assert_eq!(sections[2].level, 3);
+        // H1 body includes everything until EOF (no same-or-higher level heading)
+        let h1_body = &md[sections[0].body_range.clone()];
+        assert!(h1_body.contains("H1 body"));
+        assert!(h1_body.contains("H2 body"));
+        assert!(h1_body.contains("H3 body"));
+        // H2 body includes H3 (lower level)
+        let h2_body = &md[sections[1].body_range.clone()];
+        assert!(h2_body.contains("H2 body"));
+        assert!(h2_body.contains("H3 body"));
+        // H3 body is just its own content
+        let h3_body = &md[sections[2].body_range.clone()];
+        assert!(h3_body.contains("H3 body"));
+        assert!(!h3_body.contains("H2 body"));
+    }
+
+    #[test]
+    fn code_block_headings_ignored() {
+        let md = "# Real heading\n\nBody\n\n```markdown\n# Fake heading\n```\n\nMore body\n";
+        let sections = parse_sections(md);
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].heading_text, "Real heading");
+    }
+
+    #[test]
+    fn heading_range_includes_markers() {
+        let md = "## My Section\n\nContent here.\n";
+        let sections = parse_sections(md);
+        assert_eq!(sections.len(), 1);
+        let heading_text = &md[sections[0].heading_range.clone()];
+        assert!(heading_text.starts_with("## My Section"));
+    }
+
+    #[test]
+    fn body_extends_to_eof() {
+        let md = "# Only heading\n\nContent goes to the end.";
+        let sections = parse_sections(md);
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].body_range.end, md.len());
+        assert!(md[sections[0].body_range.clone()].contains("Content goes to the end."));
+    }
+
+    #[test]
+    fn find_exact_heading() {
+        let md = "# Title\n\nBody\n\n## Tasks\n\nTask list\n";
+        let sections = parse_sections(md);
+        let found = find_section_by_heading(&sections, "Tasks").unwrap();
+        assert_eq!(found.heading_text, "Tasks");
+        assert_eq!(found.level, 2);
+    }
+
+    #[test]
+    fn find_with_hash_prefix() {
+        let md = "# Title\n\nBody\n\n## Tasks\n\nTask list\n";
+        let sections = parse_sections(md);
+        let found = find_section_by_heading(&sections, "## Tasks").unwrap();
+        assert_eq!(found.heading_text, "Tasks");
+    }
+
+    #[test]
+    fn find_not_found() {
+        let md = "# Title\n\nBody\n\n## Tasks\n\nTask list\n";
+        let sections = parse_sections(md);
+        let err = find_section_by_heading(&sections, "Nonexistent").unwrap_err();
+        match err {
+            SectionLookupError::NotFound { available } => {
+                assert!(available.contains(&"Title".to_string()));
+                assert!(available.contains(&"Tasks".to_string()));
+            }
+            _ => panic!("Expected NotFound"),
+        }
+    }
+
+    #[test]
+    fn find_ambiguous() {
+        let md = "# Title\n\n## Notes\n\nFirst\n\n## Notes\n\nSecond\n";
+        let sections = parse_sections(md);
+        let err = find_section_by_heading(&sections, "Notes").unwrap_err();
+        match err {
+            SectionLookupError::Ambiguous { count } => assert_eq!(count, 2),
+            _ => panic!("Expected Ambiguous"),
+        }
+    }
+
+    #[test]
+    fn polish_headings() {
+        let md = "# Główne tematy\n\nTreść po polsku.\n\n## Współpraca\n\nDalsze informacje.\n";
+        let sections = parse_sections(md);
+        assert_eq!(sections.len(), 2);
+        assert_eq!(sections[0].heading_text, "Główne tematy");
+        assert_eq!(sections[1].heading_text, "Współpraca");
+        let found = find_section_by_heading(&sections, "Współpraca").unwrap();
+        assert_eq!(found.level, 2);
+    }
+
+    #[test]
+    fn h2_siblings_isolate_body() {
+        let md = "## A\n\nContent A\n\n## B\n\nContent B\n\n## C\n\nContent C\n";
+        let sections = parse_sections(md);
+        assert_eq!(sections.len(), 3);
+        let a_body = &md[sections[0].body_range.clone()];
+        assert!(a_body.contains("Content A"));
+        assert!(!a_body.contains("Content B"));
+        let b_body = &md[sections[1].body_range.clone()];
+        assert!(b_body.contains("Content B"));
+        assert!(!b_body.contains("Content C"));
+    }
+
+    #[test]
+    fn heading_with_subsections_body_includes_them() {
+        let md =
+            "## Parent\n\nParent body\n\n### Child\n\nChild body\n\n## Sibling\n\nSibling body\n";
+        let sections = parse_sections(md);
+        assert_eq!(sections.len(), 3);
+        let parent_body = &md[sections[0].body_range.clone()];
+        assert!(parent_body.contains("Parent body"));
+        assert!(parent_body.contains("Child body"));
+        assert!(!parent_body.contains("Sibling body"));
+    }
+}

--- a/crates/parser/src/transforms.rs
+++ b/crates/parser/src/transforms.rs
@@ -1,0 +1,516 @@
+use crate::frontmatter::strip_frontmatter;
+use crate::sections::{find_section_by_heading, parse_sections, SectionLookupError};
+
+/// Errors from section-based transforms.
+#[derive(Debug, Clone)]
+pub enum TransformError {
+    HeadingNotFound { available: Vec<String> },
+    HeadingAmbiguous { count: usize },
+}
+
+impl std::fmt::Display for TransformError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::HeadingNotFound { available } => {
+                write!(f, "Heading not found. Available: {}", available.join(", "))
+            }
+            Self::HeadingAmbiguous { count } => {
+                write!(f, "Heading is ambiguous: {count} matches found")
+            }
+        }
+    }
+}
+
+impl std::error::Error for TransformError {}
+
+impl From<SectionLookupError> for TransformError {
+    fn from(err: SectionLookupError) -> Self {
+        match err {
+            SectionLookupError::NotFound { available } => {
+                TransformError::HeadingNotFound { available }
+            }
+            SectionLookupError::Ambiguous { count } => TransformError::HeadingAmbiguous { count },
+        }
+    }
+}
+
+/// Position of a match in the content.
+#[derive(Debug, Clone)]
+pub struct MatchPosition {
+    pub line: usize,
+    pub column: usize,
+    pub context: String,
+}
+
+/// Errors from `replace_text`.
+#[derive(Debug, Clone)]
+pub enum ReplaceError {
+    NotFound,
+    Ambiguous {
+        count: usize,
+        positions: Vec<MatchPosition>,
+    },
+}
+
+impl std::fmt::Display for ReplaceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound => write!(f, "Text not found"),
+            Self::Ambiguous { count, positions } => {
+                writeln!(f, "Ambiguous: {count} matches found:")?;
+                for pos in positions {
+                    writeln!(
+                        f,
+                        "  line {}, col {}: ...{}...",
+                        pos.line, pos.column, pos.context
+                    )?;
+                }
+                Ok(())
+            }
+        }
+    }
+}
+
+impl std::error::Error for ReplaceError {}
+
+/// Append content at the end of the file, or at the end of a specific section.
+pub fn append_content(
+    content: &str,
+    new_text: &str,
+    heading: Option<&str>,
+) -> Result<String, TransformError> {
+    match heading {
+        None => {
+            let mut result = content.to_string();
+            if !result.ends_with('\n') {
+                result.push('\n');
+            }
+            result.push_str(new_text);
+            if !result.ends_with('\n') {
+                result.push('\n');
+            }
+            Ok(result)
+        }
+        Some(heading) => {
+            let sections = parse_sections(content);
+            let section = find_section_by_heading(&sections, heading)?;
+            let body = &content[section.body_range.clone()];
+            let trimmed_len = body.trim_end().len();
+            let content_end = section.body_range.start + trimmed_len;
+            let mut result = String::with_capacity(content.len() + new_text.len() + 2);
+            result.push_str(&content[..content_end]);
+            if !result.ends_with('\n') {
+                result.push('\n');
+            }
+            result.push_str(new_text);
+            if !result.ends_with('\n') {
+                result.push('\n');
+            }
+            let remainder = &content[section.body_range.end..];
+            if !remainder.is_empty() {
+                result.push('\n');
+            }
+            result.push_str(remainder);
+            Ok(result)
+        }
+    }
+}
+
+/// Prepend content after frontmatter (or at start), or right after a specific heading.
+pub fn prepend_content(
+    content: &str,
+    new_text: &str,
+    heading: Option<&str>,
+) -> Result<String, TransformError> {
+    match heading {
+        None => {
+            let (fm, body) = strip_frontmatter(content);
+            let mut result = String::new();
+            if !fm.is_empty() {
+                result.push_str("---\n");
+                result.push_str(&fm);
+                result.push_str("\n---\n");
+            }
+            result.push_str(new_text);
+            if !result.ends_with('\n') {
+                result.push('\n');
+            }
+            let body_trimmed = body.trim_start_matches('\n');
+            if !body_trimmed.is_empty() {
+                result.push_str(body_trimmed);
+                if !result.ends_with('\n') {
+                    result.push('\n');
+                }
+            }
+            Ok(result)
+        }
+        Some(heading) => {
+            let sections = parse_sections(content);
+            let section = find_section_by_heading(&sections, heading)?;
+            let insert_pos = section.heading_range.end;
+            let mut result = String::with_capacity(content.len() + new_text.len() + 2);
+            result.push_str(&content[..insert_pos]);
+            if !result.ends_with('\n') {
+                result.push('\n');
+            }
+            result.push_str(new_text);
+            if !result.ends_with('\n') {
+                result.push('\n');
+            }
+            result.push_str(&content[insert_pos..]);
+            Ok(result)
+        }
+    }
+}
+
+/// Replace the entire body while preserving frontmatter.
+pub fn overwrite_body(content: &str, new_text: &str) -> String {
+    let (fm, _) = strip_frontmatter(content);
+    let mut result = String::new();
+    if !fm.is_empty() {
+        result.push_str("---\n");
+        result.push_str(&fm);
+        result.push_str("\n---\n");
+    }
+    result.push_str(new_text);
+    if !result.ends_with('\n') {
+        result.push('\n');
+    }
+    result
+}
+
+/// Replace a section's body (heading + body) with new content.
+///
+/// The heading line itself is preserved; only the body is replaced.
+pub fn replace_section(
+    content: &str,
+    heading: &str,
+    new_text: &str,
+) -> Result<String, TransformError> {
+    let sections = parse_sections(content);
+    let section = find_section_by_heading(&sections, heading)?;
+    let mut result = String::with_capacity(content.len() + new_text.len());
+    result.push_str(&content[..section.heading_range.end]);
+    if !result.ends_with('\n') {
+        result.push('\n');
+    }
+    result.push_str(new_text);
+    if !result.ends_with('\n') {
+        result.push('\n');
+    }
+    let remainder = &content[section.body_range.end..];
+    if !remainder.is_empty() {
+        result.push('\n');
+    }
+    result.push_str(remainder);
+    Ok(result)
+}
+
+/// Replace exact text. Errors on 0 or 2+ matches.
+pub fn replace_text(content: &str, old: &str, new: &str) -> Result<String, ReplaceError> {
+    let matches: Vec<usize> = content.match_indices(old).map(|(i, _)| i).collect();
+
+    match matches.len() {
+        0 => Err(ReplaceError::NotFound),
+        1 => Ok(content.replacen(old, new, 1)),
+        n => {
+            let positions = matches
+                .iter()
+                .map(|&byte_pos| {
+                    let before = &content[..byte_pos];
+                    let line = before.matches('\n').count() + 1;
+                    let last_newline = before.rfind('\n').map(|p| p + 1).unwrap_or(0);
+                    let column = content[last_newline..byte_pos].chars().count() + 1;
+                    let ctx_start = content.floor_char_boundary(byte_pos.saturating_sub(20));
+                    let ctx_end =
+                        content.floor_char_boundary((byte_pos + old.len() + 20).min(content.len()));
+                    let context = content[ctx_start..ctx_end].replace('\n', "\\n");
+                    MatchPosition {
+                        line,
+                        column,
+                        context,
+                    }
+                })
+                .collect();
+            Err(ReplaceError::Ambiguous {
+                count: n,
+                positions,
+            })
+        }
+    }
+}
+
+/// Insert content immediately after an exact text anchor. Errors on 0 or 2+ matches.
+pub fn insert_after(content: &str, anchor: &str, new_text: &str) -> Result<String, ReplaceError> {
+    let matches: Vec<usize> = content.match_indices(anchor).map(|(i, _)| i).collect();
+
+    match matches.len() {
+        0 => Err(ReplaceError::NotFound),
+        1 => {
+            let pos = matches[0] + anchor.len();
+            let mut result = String::with_capacity(content.len() + new_text.len() + 2);
+            result.push_str(&content[..pos]);
+            // Ensure newline between anchor and inserted content
+            if !result.ends_with('\n') && !new_text.starts_with('\n') {
+                result.push('\n');
+            }
+            result.push_str(new_text);
+            // Ensure newline before remainder
+            if !result.ends_with('\n') && !content[pos..].starts_with('\n') {
+                result.push('\n');
+            }
+            result.push_str(&content[pos..]);
+            Ok(result)
+        }
+        n => {
+            let positions = matches
+                .iter()
+                .map(|&byte_pos| {
+                    let before = &content[..byte_pos];
+                    let line = before.matches('\n').count() + 1;
+                    let last_newline = before.rfind('\n').map(|p| p + 1).unwrap_or(0);
+                    let column = content[last_newline..byte_pos].chars().count() + 1;
+                    let ctx_start = content.floor_char_boundary(byte_pos.saturating_sub(20));
+                    let ctx_end = content
+                        .floor_char_boundary((byte_pos + anchor.len() + 20).min(content.len()));
+                    let context = content[ctx_start..ctx_end].replace('\n', "\\n");
+                    MatchPosition {
+                        line,
+                        column,
+                        context,
+                    }
+                })
+                .collect();
+            Err(ReplaceError::Ambiguous {
+                count: n,
+                positions,
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- append_content tests --
+
+    #[test]
+    fn append_to_file() {
+        let content = "# Title\n\nExisting body.\n";
+        let result = append_content(content, "New line.", None).unwrap();
+        assert!(result.ends_with("New line.\n"));
+        assert!(result.contains("Existing body."));
+    }
+
+    #[test]
+    fn append_to_section() {
+        let content = "# Title\n\nBody\n\n## Tasks\n\n- Task 1\n\n## Notes\n\nNote body\n";
+        let result = append_content(content, "- Task 2", Some("## Tasks")).unwrap();
+        // Task 2 should be between Tasks and Notes sections
+        let tasks_pos = result.find("- Task 2").unwrap();
+        let notes_pos = result.find("## Notes").unwrap();
+        assert!(tasks_pos < notes_pos);
+        assert!(result.contains("- Task 1"));
+        // No extra blank line between existing and new content
+        assert!(result.contains("- Task 1\n- Task 2"));
+        // Blank line before next heading is preserved
+        assert!(result.contains("- Task 2\n\n## Notes"));
+    }
+
+    #[test]
+    fn append_to_last_section() {
+        let content = "# Title\n\n## End\n\nLast content.\n";
+        let result = append_content(content, "Appended.", Some("## End")).unwrap();
+        assert!(result.contains("Last content."));
+        assert!(result.contains("Appended."));
+    }
+
+    // -- prepend_content tests --
+
+    #[test]
+    fn prepend_no_frontmatter() {
+        let content = "# Title\n\nBody\n";
+        let result = prepend_content(content, "Prepended text.", None).unwrap();
+        let prepend_pos = result.find("Prepended text.").unwrap();
+        let title_pos = result.find("# Title").unwrap();
+        assert!(prepend_pos < title_pos);
+    }
+
+    #[test]
+    fn prepend_with_frontmatter() {
+        let content = "---\ntags: [test]\n---\n# Title\n\nBody\n";
+        let result = prepend_content(content, "Prepended.", None).unwrap();
+        // Frontmatter should be preserved
+        assert!(result.contains("---\ntags: [test]\n---"));
+        // Prepended text should come after frontmatter but before body
+        let fm_end = result.find("---\n").unwrap();
+        let second_fm = result[fm_end + 4..].find("---\n").unwrap() + fm_end + 4;
+        let prepend_pos = result.find("Prepended.").unwrap();
+        let title_pos = result.find("# Title").unwrap();
+        assert!(prepend_pos > second_fm);
+        assert!(prepend_pos < title_pos);
+    }
+
+    #[test]
+    fn prepend_with_heading() {
+        let content = "# Title\n\nBody\n\n## Tasks\n\nExisting tasks.\n";
+        let result = prepend_content(content, "New task.", Some("## Tasks")).unwrap();
+        let heading_pos = result.find("## Tasks").unwrap();
+        let new_pos = result.find("New task.").unwrap();
+        let existing_pos = result.find("Existing tasks.").unwrap();
+        assert!(new_pos > heading_pos);
+        assert!(new_pos < existing_pos);
+    }
+
+    // -- overwrite_body tests --
+
+    #[test]
+    fn overwrite_no_frontmatter() {
+        let content = "# Old Title\n\nOld body.\n";
+        let result = overwrite_body(content, "# New Title\n\nNew body.");
+        assert_eq!(result, "# New Title\n\nNew body.\n");
+        assert!(!result.contains("Old"));
+    }
+
+    #[test]
+    fn overwrite_with_frontmatter() {
+        let content = "---\ntags: [keep]\n---\n# Old Title\n\nOld body.\n";
+        let result = overwrite_body(content, "# New Title\n\nNew body.");
+        assert!(result.contains("tags: [keep]"));
+        assert!(result.contains("New body."));
+        assert!(!result.contains("Old body."));
+    }
+
+    // -- replace_section tests --
+
+    #[test]
+    fn replace_section_basic() {
+        let content = "# Title\n\n## Tasks\n\n- Old task\n\n## Notes\n\nNote body\n";
+        let result = replace_section(content, "## Tasks", "- New task 1\n- New task 2").unwrap();
+        assert!(result.contains("## Tasks"));
+        assert!(result.contains("- New task 1"));
+        assert!(result.contains("- New task 2"));
+        assert!(!result.contains("- Old task"));
+        assert!(result.contains("## Notes"));
+        assert!(result.contains("Note body"));
+        // Blank line before next heading is preserved
+        assert!(result.contains("- New task 2\n\n## Notes"));
+    }
+
+    #[test]
+    fn replace_section_with_subsections() {
+        let content =
+            "## Parent\n\nParent body\n\n### Child\n\nChild body\n\n## Sibling\n\nSibling body\n";
+        let result = replace_section(content, "## Parent", "Replaced content.").unwrap();
+        assert!(result.contains("## Parent"));
+        assert!(result.contains("Replaced content."));
+        assert!(!result.contains("Parent body"));
+        assert!(!result.contains("Child body")); // subsections are part of parent
+        assert!(result.contains("## Sibling"));
+        assert!(result.contains("Sibling body"));
+    }
+
+    #[test]
+    fn replace_section_heading_not_found() {
+        let content = "# Title\n\n## Tasks\n\nBody\n";
+        let err = replace_section(content, "## Nonexistent", "New").unwrap_err();
+        match err {
+            TransformError::HeadingNotFound { available } => {
+                assert!(available.contains(&"Tasks".to_string()));
+            }
+            _ => panic!("Expected HeadingNotFound"),
+        }
+    }
+
+    // -- replace_text tests --
+
+    #[test]
+    fn replace_text_single() {
+        let content = "Hello world, this is a test.";
+        let result = replace_text(content, "world", "earth").unwrap();
+        assert_eq!(result, "Hello earth, this is a test.");
+    }
+
+    #[test]
+    fn replace_text_not_found() {
+        let content = "Hello world.";
+        let err = replace_text(content, "mars", "earth").unwrap_err();
+        assert!(matches!(err, ReplaceError::NotFound));
+    }
+
+    #[test]
+    fn replace_text_ambiguous() {
+        let content = "foo bar foo baz foo";
+        let err = replace_text(content, "foo", "qux").unwrap_err();
+        match err {
+            ReplaceError::Ambiguous { count, positions } => {
+                assert_eq!(count, 3);
+                assert_eq!(positions.len(), 3);
+                assert_eq!(positions[0].line, 1);
+                assert_eq!(positions[0].column, 1);
+            }
+            _ => panic!("Expected Ambiguous"),
+        }
+    }
+
+    #[test]
+    fn replace_text_multiline() {
+        let content = "Line one\nLine two\nLine three\n";
+        let result = replace_text(content, "Line two", "LINE TWO").unwrap();
+        assert_eq!(result, "Line one\nLINE TWO\nLine three\n");
+    }
+
+    // -- insert_after tests --
+
+    #[test]
+    fn insert_after_basic() {
+        let content = "# Title\n\n- Item 1\n- Item 2\n\n## Notes\n";
+        // Agent provides anchor and content without worrying about newlines
+        let result = insert_after(content, "- Item 1", "- Item 1.5").unwrap();
+        assert!(result.contains("- Item 1\n- Item 1.5\n- Item 2"));
+    }
+
+    #[test]
+    fn insert_after_anchor_with_trailing_newline() {
+        let content = "# Title\n\n- Item 1\n- Item 2\n";
+        let result = insert_after(content, "- Item 1\n", "- Item 1.5\n").unwrap();
+        assert!(result.contains("- Item 1\n- Item 1.5\n- Item 2"));
+    }
+
+    #[test]
+    fn insert_after_not_found() {
+        let content = "Hello world.";
+        let err = insert_after(content, "mars", "new text").unwrap_err();
+        assert!(matches!(err, ReplaceError::NotFound));
+    }
+
+    #[test]
+    fn insert_after_ambiguous() {
+        let content = "foo bar foo baz foo";
+        let err = insert_after(content, "foo", "new").unwrap_err();
+        match err {
+            ReplaceError::Ambiguous { count, positions } => {
+                assert_eq!(count, 3);
+                assert_eq!(positions.len(), 3);
+            }
+            _ => panic!("Expected Ambiguous"),
+        }
+    }
+
+    #[test]
+    fn insert_after_multiline_anchor() {
+        let content = "First line\nSecond line\nThird line\n";
+        let result = insert_after(content, "First line\nSecond line", "Inserted").unwrap();
+        assert!(result.contains("Second line\nInserted\nThird line"));
+    }
+
+    #[test]
+    fn polish_content_transforms() {
+        let content = "# Główne tematy\n\nTreść po polsku z [[linkiem]].\n\n## Współpraca\n\nSzczegóły współpracy.\n";
+        let result = append_content(content, "Nowa treść.", Some("## Współpraca")).unwrap();
+        assert!(result.contains("Szczegóły współpracy."));
+        assert!(result.contains("Nowa treść."));
+        assert!(result.contains("Główne tematy"));
+    }
+}

--- a/crates/writer/Cargo.toml
+++ b/crates/writer/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "kajet-writer"
+version = "0.2.0"
+edition = "2021"
+
+[dependencies]
+kajet-core = { path = "../core", features = ["test-utils"] }
+kajet-parser = { path = "../parser" }
+anyhow = "1"
+chrono = { version = "0.4", features = ["serde"] }
+chrono-tz = "0.10"
+tokio = { version = "1", features = ["fs", "sync", "rt"] }
+tracing = "0.1"
+unicode-normalization = "0.1"
+ignore = "0.4"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["test-util", "macros", "fs", "rt-multi-thread"] }
+tempfile = "3"

--- a/crates/writer/src/backup.rs
+++ b/crates/writer/src/backup.rs
@@ -1,0 +1,106 @@
+use anyhow::Result;
+use std::path::{Path, PathBuf};
+
+/// Create a backup of a file before destructive edits.
+///
+/// Saves to `{db_path}/backups/{timestamp}_{filename}`.
+/// Returns the path to the backup file.
+pub async fn create_backup(
+    source_path: &Path,
+    db_path: &Path,
+    max_per_file: usize,
+) -> Result<PathBuf> {
+    let backup_dir = db_path.join("backups");
+    tokio::fs::create_dir_all(&backup_dir).await?;
+
+    let filename = source_path
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| "unknown".into());
+
+    let timestamp = chrono::Utc::now().format("%Y%m%dT%H%M%S");
+    let backup_name = format!("{timestamp}_{filename}");
+    let backup_path = backup_dir.join(&backup_name);
+
+    tokio::fs::copy(source_path, &backup_path).await?;
+
+    tracing::debug!(
+        backup = %backup_path.display(),
+        source = %source_path.display(),
+        "Backup created"
+    );
+
+    cleanup_old_backups(&backup_dir, &filename, max_per_file).await?;
+
+    Ok(backup_path)
+}
+
+/// Keep only the N most recent backups per filename.
+async fn cleanup_old_backups(backup_dir: &Path, filename: &str, max_per_file: usize) -> Result<()> {
+    let mut entries = Vec::new();
+    let mut read_dir = tokio::fs::read_dir(backup_dir).await?;
+
+    while let Some(entry) = read_dir.next_entry().await? {
+        let name = entry.file_name().to_string_lossy().to_string();
+        // Match pattern: {timestamp}_{filename}
+        if name.ends_with(&format!("_{filename}")) {
+            entries.push((name, entry.path()));
+        }
+    }
+
+    if entries.len() <= max_per_file {
+        return Ok(());
+    }
+
+    // Sort by name (timestamp prefix ensures chronological order)
+    entries.sort_by(|a, b| a.0.cmp(&b.0));
+
+    // Remove oldest entries
+    let to_remove = entries.len() - max_per_file;
+    for (_, path) in entries.iter().take(to_remove) {
+        tokio::fs::remove_file(path).await?;
+        tracing::debug!(path = %path.display(), "Removed old backup");
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn backup_create_and_cleanup() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("db");
+        tokio::fs::create_dir_all(&db_path).await.unwrap();
+
+        let source = dir.path().join("note.md");
+        tokio::fs::write(&source, "# Content").await.unwrap();
+
+        // Create 3 backups with max 2
+        let b1 = create_backup(&source, &db_path, 2).await.unwrap();
+        assert!(b1.exists());
+
+        // Small delay so timestamps differ
+        tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+        let b2 = create_backup(&source, &db_path, 2).await.unwrap();
+        assert!(b2.exists());
+
+        tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+        let b3 = create_backup(&source, &db_path, 2).await.unwrap();
+        assert!(b3.exists());
+
+        // Count remaining backups for "note.md"
+        let backup_dir = db_path.join("backups");
+        let mut count = 0;
+        let mut read_dir = tokio::fs::read_dir(&backup_dir).await.unwrap();
+        while let Some(entry) = read_dir.next_entry().await.unwrap() {
+            let name = entry.file_name().to_string_lossy().to_string();
+            if name.ends_with("_note.md") {
+                count += 1;
+            }
+        }
+        assert_eq!(count, 2, "Should keep only 2 most recent backups");
+    }
+}

--- a/crates/writer/src/lib.rs
+++ b/crates/writer/src/lib.rs
@@ -31,27 +31,32 @@ fn ensure_within_vault(rel_path: &str) -> Result<()> {
 
 /// Verify that a resolved absolute path is actually within the vault after symlink resolution.
 ///
-/// Canonicalizes both paths to resolve symlinks, then checks the prefix relationship.
-/// For new files (create), canonicalizes the parent directory instead.
+/// Walks up the path to find the deepest existing ancestor, canonicalizes it,
+/// then checks the prefix relationship. This works for paths where intermediate
+/// directories don't exist yet (they'll be created later by `create_dir_all`).
 async fn ensure_canonical_within_vault(abs_path: &Path, vault_path: &Path) -> Result<()> {
     let canonical_vault = tokio::fs::canonicalize(vault_path).await?;
 
-    // For existing files, canonicalize directly. For new files, canonicalize parent.
-    let canonical_target = if tokio::fs::metadata(abs_path).await.is_ok() {
-        tokio::fs::canonicalize(abs_path).await?
-    } else {
-        // File doesn't exist yet — canonicalize parent + append filename
-        let parent = abs_path
-            .parent()
-            .ok_or_else(|| anyhow::anyhow!("Path has no parent: '{}'", abs_path.display()))?;
-        let filename = abs_path
-            .file_name()
-            .ok_or_else(|| anyhow::anyhow!("Path has no filename: '{}'", abs_path.display()))?;
-        let canonical_parent = tokio::fs::canonicalize(parent).await?;
-        canonical_parent.join(filename)
-    };
+    // Find the deepest existing ancestor and collect non-existent suffixes
+    let mut existing = abs_path.to_path_buf();
+    let mut suffix_parts: Vec<std::ffi::OsString> = Vec::new();
 
-    if !canonical_target.starts_with(&canonical_vault) {
+    while tokio::fs::metadata(&existing).await.is_err() {
+        if let Some(name) = existing.file_name() {
+            suffix_parts.push(name.to_owned());
+        }
+        match existing.parent() {
+            Some(parent) => existing = parent.to_path_buf(),
+            None => bail!("Cannot resolve path: '{}'", abs_path.display()),
+        }
+    }
+
+    let mut canonical = tokio::fs::canonicalize(&existing).await?;
+    for part in suffix_parts.iter().rev() {
+        canonical.push(part);
+    }
+
+    if !canonical.starts_with(&canonical_vault) {
         bail!(
             "Path escapes vault via symlink: '{}' resolves outside '{}'",
             abs_path.display(),
@@ -101,13 +106,13 @@ impl NoteWriter {
             );
         }
 
+        // Verify the path doesn't escape vault via symlinks BEFORE creating directories
+        ensure_canonical_within_vault(&abs_path, &self.vault_path).await?;
+
         // Create parent directories if needed
         if let Some(parent) = abs_path.parent() {
             tokio::fs::create_dir_all(parent).await?;
         }
-
-        // Verify the path doesn't escape vault via symlinks
-        ensure_canonical_within_vault(&abs_path, &self.vault_path).await?;
 
         // Build the note content
         let title = title_from_path(&rel_path);

--- a/crates/writer/src/lib.rs
+++ b/crates/writer/src/lib.rs
@@ -1,0 +1,776 @@
+pub mod backup;
+pub mod resolve;
+pub mod timestamp;
+pub mod types;
+
+pub use types::{CreateNoteParams, CreateNoteResult, EditMode, EditNoteParams, EditNoteResult};
+
+use anyhow::{bail, Result};
+use kajet_core::config::WriterConfig;
+use kajet_core::traits::DocumentStore;
+use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+use tracing::instrument;
+
+/// Validate that a path stays within the vault — rejects `..` traversal and absolute paths.
+fn ensure_within_vault(rel_path: &str) -> Result<()> {
+    let path = Path::new(rel_path);
+    for component in path.components() {
+        if matches!(component, Component::ParentDir) {
+            bail!(
+                "Path traversal rejected: '{}' contains '..' component",
+                rel_path
+            );
+        }
+        if matches!(component, Component::RootDir | Component::Prefix(_)) {
+            bail!("Absolute paths are not allowed: '{}'", rel_path);
+        }
+    }
+    Ok(())
+}
+
+/// Verify that a resolved absolute path is actually within the vault after symlink resolution.
+///
+/// Canonicalizes both paths to resolve symlinks, then checks the prefix relationship.
+/// For new files (create), canonicalizes the parent directory instead.
+async fn ensure_canonical_within_vault(abs_path: &Path, vault_path: &Path) -> Result<()> {
+    let canonical_vault = tokio::fs::canonicalize(vault_path).await?;
+
+    // For existing files, canonicalize directly. For new files, canonicalize parent.
+    let canonical_target = if tokio::fs::metadata(abs_path).await.is_ok() {
+        tokio::fs::canonicalize(abs_path).await?
+    } else {
+        // File doesn't exist yet — canonicalize parent + append filename
+        let parent = abs_path
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("Path has no parent: '{}'", abs_path.display()))?;
+        let filename = abs_path
+            .file_name()
+            .ok_or_else(|| anyhow::anyhow!("Path has no filename: '{}'", abs_path.display()))?;
+        let canonical_parent = tokio::fs::canonicalize(parent).await?;
+        canonical_parent.join(filename)
+    };
+
+    if !canonical_target.starts_with(&canonical_vault) {
+        bail!(
+            "Path escapes vault via symlink: '{}' resolves outside '{}'",
+            abs_path.display(),
+            vault_path.display()
+        );
+    }
+    Ok(())
+}
+
+pub struct NoteWriter {
+    vault_path: PathBuf,
+    db_path: PathBuf,
+    config: WriterConfig,
+    doc_store: Option<Arc<dyn DocumentStore>>,
+}
+
+impl NoteWriter {
+    pub fn new(
+        vault_path: PathBuf,
+        db_path: PathBuf,
+        config: WriterConfig,
+        doc_store: Option<Arc<dyn DocumentStore>>,
+    ) -> Self {
+        Self {
+            vault_path,
+            db_path,
+            config,
+            doc_store,
+        }
+    }
+
+    /// Create a new note in the vault.
+    #[instrument(level = "info", skip(self, params), fields(target = %params.target))]
+    pub async fn create(&self, params: CreateNoteParams) -> Result<CreateNoteResult> {
+        if params.content.is_empty() {
+            bail!("Content cannot be empty");
+        }
+
+        let rel_path = normalize_target(&params.target);
+        ensure_within_vault(&rel_path)?;
+        let abs_path = self.vault_path.join(&rel_path);
+
+        if tokio::fs::metadata(&abs_path).await.is_ok() {
+            bail!(
+                "File already exists: '{}'. Use edit_note instead.",
+                rel_path
+            );
+        }
+
+        // Create parent directories if needed
+        if let Some(parent) = abs_path.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+
+        // Verify the path doesn't escape vault via symlinks
+        ensure_canonical_within_vault(&abs_path, &self.vault_path).await?;
+
+        // Build the note content
+        let title = title_from_path(&rel_path);
+        let ts = if self.config.timestamps.enabled {
+            Some(timestamp::format_now(&self.config.timestamps)?)
+        } else {
+            None
+        };
+
+        let frontmatter = kajet_parser::generate_frontmatter(
+            &title,
+            &params.tags,
+            &self.config.frontmatter.default_tags,
+            &params.aliases,
+            ts.as_deref(),
+            &self.config.timestamps.created_field,
+            &self.config.timestamps.modified_field,
+        );
+
+        let full_content = format!("{frontmatter}{}", params.content);
+        let bytes = full_content.len();
+
+        tokio::fs::write(&abs_path, &full_content).await?;
+
+        tracing::info!(path = %rel_path, bytes, "Note created");
+
+        Ok(CreateNoteResult {
+            path: rel_path,
+            absolute_path: abs_path,
+            bytes_written: bytes,
+        })
+    }
+
+    /// Edit an existing note in the vault.
+    #[instrument(level = "info", skip(self, params), fields(path = %params.path, mode = %params.mode.as_str()))]
+    pub async fn edit(&self, params: EditNoteParams) -> Result<EditNoteResult> {
+        if params.content.is_empty() && params.mode != EditMode::ReplaceText {
+            bail!("Content cannot be empty");
+        }
+
+        self.validate_edit_params(&params)?;
+
+        // Resolve path
+        let resolved =
+            resolve::resolve_note_path(&params.path, &self.vault_path, self.doc_store.as_ref())
+                .await?;
+
+        // Verify the resolved path doesn't escape vault via symlinks
+        ensure_canonical_within_vault(&resolved.absolute, &self.vault_path).await?;
+
+        // Read current content
+        let current = tokio::fs::read_to_string(&resolved.absolute).await?;
+
+        // Backup before destructive ops
+        let backup_path = if params.mode.is_destructive() && self.config.backup_enabled {
+            Some(
+                backup::create_backup(
+                    &resolved.absolute,
+                    &self.db_path,
+                    self.config.backup_max_per_file,
+                )
+                .await?,
+            )
+        } else {
+            None
+        };
+
+        // Apply transform
+        let transformed = self.apply_transform(&current, &params)?;
+
+        // Update modified timestamp — only if the field already exists in frontmatter.
+        // This avoids adding duplicate timestamp fields to notes created by other tools
+        // (e.g. Obsidian with Polish field names like "Data aktualizacji").
+        let final_content = if self.config.timestamps.enabled
+            && !self.config.timestamps.modified_field.is_empty()
+        {
+            let ts = timestamp::format_now(&self.config.timestamps)?;
+            kajet_parser::update_existing_frontmatter_field(
+                &transformed,
+                &self.config.timestamps.modified_field,
+                &ts,
+            )
+        } else {
+            transformed
+        };
+
+        let bytes = final_content.len();
+        tokio::fs::write(&resolved.absolute, &final_content).await?;
+
+        tracing::info!(
+            path = %resolved.relative,
+            mode = %params.mode.as_str(),
+            bytes,
+            backup = backup_path.is_some(),
+            "Note edited"
+        );
+
+        Ok(EditNoteResult {
+            path: resolved.relative,
+            absolute_path: resolved.absolute,
+            mode: params.mode.as_str().to_string(),
+            bytes_written: bytes,
+            backup_path,
+        })
+    }
+
+    fn validate_edit_params(&self, params: &EditNoteParams) -> Result<()> {
+        match params.mode {
+            EditMode::Overwrite if params.target_heading.is_some() => {
+                bail!("Cannot use target_heading with overwrite mode");
+            }
+            EditMode::ReplaceSection if params.target_heading.is_none() => {
+                bail!("replace_section requires target_heading");
+            }
+            EditMode::ReplaceText | EditMode::InsertAfter if params.old_text.is_none() => {
+                bail!("{} requires old_text", params.mode.as_str());
+            }
+            _ => Ok(()),
+        }
+    }
+
+    fn apply_transform(&self, current: &str, params: &EditNoteParams) -> Result<String> {
+        match params.mode {
+            EditMode::Append => kajet_parser::append_content(
+                current,
+                &params.content,
+                params.target_heading.as_deref(),
+            )
+            .map_err(|e| anyhow::anyhow!("{e}")),
+
+            EditMode::Prepend => kajet_parser::prepend_content(
+                current,
+                &params.content,
+                params.target_heading.as_deref(),
+            )
+            .map_err(|e| anyhow::anyhow!("{e}")),
+
+            EditMode::Overwrite => Ok(kajet_parser::overwrite_body(current, &params.content)),
+
+            EditMode::ReplaceSection => {
+                let heading = params.target_heading.as_deref().unwrap();
+                kajet_parser::replace_section(current, heading, &params.content)
+                    .map_err(|e| anyhow::anyhow!("{e}"))
+            }
+
+            EditMode::ReplaceText => {
+                let old = params.old_text.as_deref().unwrap();
+                kajet_parser::replace_text(current, old, &params.content)
+                    .map_err(|e| anyhow::anyhow!("{e}"))
+            }
+
+            EditMode::InsertAfter => {
+                let anchor = params.old_text.as_deref().unwrap();
+                kajet_parser::insert_after(current, anchor, &params.content)
+                    .map_err(|e| anyhow::anyhow!("{e}"))
+            }
+        }
+    }
+}
+
+/// Normalize a target path: ensure `.md` extension, normalize separators.
+fn normalize_target(target: &str) -> String {
+    let normalized = target.replace('\\', "/");
+    if normalized.ends_with(".md") {
+        normalized
+    } else {
+        format!("{normalized}.md")
+    }
+}
+
+/// Extract a title from a relative file path (filename without extension).
+fn title_from_path(rel_path: &str) -> String {
+    Path::new(rel_path)
+        .file_stem()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_else(|| rel_path.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kajet_core::config::WriterConfig;
+
+    fn test_config() -> WriterConfig {
+        WriterConfig {
+            timestamps: kajet_core::config::TimestampConfig {
+                enabled: false,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn create_basic() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = dir.path().to_path_buf();
+        let db = dir.path().join(".kajet");
+
+        let writer = NoteWriter::new(vault.clone(), db, test_config(), None);
+        let result = writer
+            .create(CreateNoteParams {
+                target: "hello.md".into(),
+                content: "# Hello\n\nWorld".into(),
+                tags: vec!["test".into()],
+                aliases: vec![],
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.path, "hello.md");
+        assert!(result.absolute_path.exists());
+        let content = tokio::fs::read_to_string(&result.absolute_path)
+            .await
+            .unwrap();
+        assert!(content.contains("# Hello"));
+        assert!(content.contains("tags: [test]"));
+    }
+
+    #[tokio::test]
+    async fn create_error_if_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = dir.path().to_path_buf();
+        let db = dir.path().join(".kajet");
+
+        tokio::fs::write(vault.join("existing.md"), "content")
+            .await
+            .unwrap();
+
+        let writer = NoteWriter::new(vault, db, test_config(), None);
+        let result = writer
+            .create(CreateNoteParams {
+                target: "existing.md".into(),
+                content: "new content".into(),
+                tags: vec![],
+                aliases: vec![],
+            })
+            .await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("already exists"));
+    }
+
+    #[tokio::test]
+    async fn create_parent_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = dir.path().to_path_buf();
+        let db = dir.path().join(".kajet");
+
+        let writer = NoteWriter::new(vault.clone(), db, test_config(), None);
+        let result = writer
+            .create(CreateNoteParams {
+                target: "sub/folder/note".into(),
+                content: "Deep note".into(),
+                tags: vec![],
+                aliases: vec![],
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.path, "sub/folder/note.md");
+        assert!(vault.join("sub/folder/note.md").exists());
+    }
+
+    #[tokio::test]
+    async fn create_with_timestamps() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = dir.path().to_path_buf();
+        let db = dir.path().join(".kajet");
+
+        let config = WriterConfig {
+            timestamps: kajet_core::config::TimestampConfig {
+                enabled: true,
+                format: "date_only".into(),
+                timezone: "UTC".into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let writer = NoteWriter::new(vault, db, config, None);
+        let result = writer
+            .create(CreateNoteParams {
+                target: "timestamped".into(),
+                content: "Body".into(),
+                tags: vec![],
+                aliases: vec![],
+            })
+            .await
+            .unwrap();
+
+        let content = tokio::fs::read_to_string(&result.absolute_path)
+            .await
+            .unwrap();
+        assert!(content.contains("created:"));
+        assert!(content.contains("modified:"));
+    }
+
+    #[tokio::test]
+    async fn edit_append() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = dir.path().to_path_buf();
+        let db = dir.path().join(".kajet");
+
+        let note_path = vault.join("note.md");
+        tokio::fs::write(&note_path, "# Title\n\nOriginal body.\n")
+            .await
+            .unwrap();
+
+        let writer = NoteWriter::new(vault, db, test_config(), None);
+        let result = writer
+            .edit(EditNoteParams {
+                path: "note.md".into(),
+                content: "Appended line.".into(),
+                mode: EditMode::Append,
+                target_heading: None,
+                old_text: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(result.mode, "append");
+        let content = tokio::fs::read_to_string(&note_path).await.unwrap();
+        assert!(content.contains("Original body."));
+        assert!(content.contains("Appended line."));
+    }
+
+    #[tokio::test]
+    async fn edit_overwrite_with_backup() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = dir.path().to_path_buf();
+        let db = dir.path().join(".kajet");
+
+        let note_path = vault.join("note.md");
+        tokio::fs::write(&note_path, "# Old\n\nOld body.\n")
+            .await
+            .unwrap();
+
+        let config = WriterConfig {
+            backup_enabled: true,
+            timestamps: kajet_core::config::TimestampConfig {
+                enabled: false,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let writer = NoteWriter::new(vault, db.clone(), config, None);
+        let result = writer
+            .edit(EditNoteParams {
+                path: "note.md".into(),
+                content: "# New\n\nNew body.".into(),
+                mode: EditMode::Overwrite,
+                target_heading: None,
+                old_text: None,
+            })
+            .await
+            .unwrap();
+
+        assert!(result.backup_path.is_some());
+        let backup = result.backup_path.unwrap();
+        assert!(backup.exists());
+        // Backup should contain old content
+        let backup_content = tokio::fs::read_to_string(&backup).await.unwrap();
+        assert!(backup_content.contains("Old body."));
+    }
+
+    #[tokio::test]
+    async fn edit_updates_existing_modified_timestamp() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = dir.path().to_path_buf();
+        let db = dir.path().join(".kajet");
+
+        let note_path = vault.join("note.md");
+        // Note already has modified: field (e.g. created by kajet)
+        tokio::fs::write(
+            &note_path,
+            "---\ntitle: \"Note\"\nmodified: 2025-01-01\n---\n# Body\n",
+        )
+        .await
+        .unwrap();
+
+        let config = WriterConfig {
+            timestamps: kajet_core::config::TimestampConfig {
+                enabled: true,
+                format: "date_only".into(),
+                timezone: "UTC".into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let writer = NoteWriter::new(vault, db, config, None);
+        writer
+            .edit(EditNoteParams {
+                path: "note.md".into(),
+                content: "Appended.".into(),
+                mode: EditMode::Append,
+                target_heading: None,
+                old_text: None,
+            })
+            .await
+            .unwrap();
+
+        let content = tokio::fs::read_to_string(&note_path).await.unwrap();
+        assert!(content.contains("modified:"));
+        assert!(
+            !content.contains("2025-01-01"),
+            "Old timestamp should be replaced"
+        );
+    }
+
+    #[tokio::test]
+    async fn edit_does_not_add_missing_modified() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = dir.path().to_path_buf();
+        let db = dir.path().join(".kajet");
+
+        let note_path = vault.join("note.md");
+        // Note without modified: field (e.g. created by Obsidian)
+        tokio::fs::write(&note_path, "---\ntitle: \"Note\"\n---\n# Body\n")
+            .await
+            .unwrap();
+
+        let config = WriterConfig {
+            timestamps: kajet_core::config::TimestampConfig {
+                enabled: true,
+                format: "date_only".into(),
+                timezone: "UTC".into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let writer = NoteWriter::new(vault, db, config, None);
+        writer
+            .edit(EditNoteParams {
+                path: "note.md".into(),
+                content: "Appended.".into(),
+                mode: EditMode::Append,
+                target_heading: None,
+                old_text: None,
+            })
+            .await
+            .unwrap();
+
+        let content = tokio::fs::read_to_string(&note_path).await.unwrap();
+        assert!(
+            !content.contains("modified:"),
+            "Should not add modified: to note that didn't have it"
+        );
+    }
+
+    #[tokio::test]
+    async fn edit_skips_empty_modified_field() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = dir.path().to_path_buf();
+        let db = dir.path().join(".kajet");
+
+        let note_path = vault.join("note.md");
+        tokio::fs::write(&note_path, "---\ntitle: \"Note\"\n---\n# Body\n")
+            .await
+            .unwrap();
+
+        let config = WriterConfig {
+            timestamps: kajet_core::config::TimestampConfig {
+                enabled: true,
+                modified_field: "".into(), // disabled
+                format: "date_only".into(),
+                timezone: "UTC".into(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        let writer = NoteWriter::new(vault, db, config, None);
+        writer
+            .edit(EditNoteParams {
+                path: "note.md".into(),
+                content: "Appended.".into(),
+                mode: EditMode::Append,
+                target_heading: None,
+                old_text: None,
+            })
+            .await
+            .unwrap();
+
+        let content = tokio::fs::read_to_string(&note_path).await.unwrap();
+        assert!(!content.contains("modified:"));
+    }
+
+    #[tokio::test]
+    async fn create_rejects_path_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = dir.path().to_path_buf();
+        let db = dir.path().join(".kajet");
+
+        let writer = NoteWriter::new(vault, db, test_config(), None);
+
+        // Direct parent traversal
+        let result = writer
+            .create(CreateNoteParams {
+                target: "../../etc/evil".into(),
+                content: "pwned".into(),
+                tags: vec![],
+                aliases: vec![],
+            })
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("traversal"));
+
+        // Nested traversal
+        let result = writer
+            .create(CreateNoteParams {
+                target: "sub/../../../etc/evil".into(),
+                content: "pwned".into(),
+                tags: vec![],
+                aliases: vec![],
+            })
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("traversal"));
+    }
+
+    #[tokio::test]
+    async fn create_rejects_absolute_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = dir.path().to_path_buf();
+        let db = dir.path().join(".kajet");
+
+        let writer = NoteWriter::new(vault, db, test_config(), None);
+        let result = writer
+            .create(CreateNoteParams {
+                target: "/etc/passwd".into(),
+                content: "pwned".into(),
+                tags: vec![],
+                aliases: vec![],
+            })
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Absolute"));
+    }
+
+    #[tokio::test]
+    async fn edit_rejects_path_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = dir.path().to_path_buf();
+        let db = dir.path().join(".kajet");
+
+        let writer = NoteWriter::new(vault, db, test_config(), None);
+        let result = writer
+            .edit(EditNoteParams {
+                path: "../../etc/passwd".into(),
+                content: "pwned".into(),
+                mode: EditMode::Append,
+                target_heading: None,
+                old_text: None,
+            })
+            .await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("traversal"));
+    }
+
+    #[tokio::test]
+    async fn create_rejects_symlink_escape() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = dir.path().join("vault");
+        let outside = dir.path().join("outside");
+        let db = dir.path().join(".kajet");
+
+        tokio::fs::create_dir_all(&vault).await.unwrap();
+        tokio::fs::create_dir_all(&outside).await.unwrap();
+
+        // Create a symlink inside the vault pointing outside
+        tokio::fs::symlink(&outside, vault.join("escape"))
+            .await
+            .unwrap();
+
+        let writer = NoteWriter::new(vault, db, test_config(), None);
+        let result = writer
+            .create(CreateNoteParams {
+                target: "escape/evil".into(),
+                content: "pwned".into(),
+                tags: vec![],
+                aliases: vec![],
+            })
+            .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("symlink"),
+            "Expected symlink error, got: {err}"
+        );
+        // Verify file was NOT created outside vault
+        assert!(!outside.join("evil.md").exists());
+    }
+
+    #[tokio::test]
+    async fn edit_rejects_symlink_escape() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = dir.path().join("vault");
+        let outside = dir.path().join("outside");
+        let db = dir.path().join(".kajet");
+
+        tokio::fs::create_dir_all(&vault).await.unwrap();
+        tokio::fs::create_dir_all(&outside).await.unwrap();
+
+        // Create a real file outside the vault
+        let outside_note = outside.join("secret.md");
+        tokio::fs::write(&outside_note, "# Secret\n\nDo not edit.")
+            .await
+            .unwrap();
+
+        // Symlink it into the vault
+        tokio::fs::symlink(&outside_note, vault.join("secret.md"))
+            .await
+            .unwrap();
+
+        let writer = NoteWriter::new(vault, db, test_config(), None);
+        let result = writer
+            .edit(EditNoteParams {
+                path: "secret.md".into(),
+                content: "pwned".into(),
+                mode: EditMode::Append,
+                target_heading: None,
+                old_text: None,
+            })
+            .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("symlink"),
+            "Expected symlink error, got: {err}"
+        );
+        // Verify original file was NOT modified
+        let content = tokio::fs::read_to_string(&outside_note).await.unwrap();
+        assert_eq!(content, "# Secret\n\nDo not edit.");
+    }
+
+    #[tokio::test]
+    async fn edit_empty_content_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = dir.path().to_path_buf();
+        let db = dir.path().join(".kajet");
+
+        tokio::fs::write(vault.join("note.md"), "content")
+            .await
+            .unwrap();
+
+        let writer = NoteWriter::new(vault, db, test_config(), None);
+        let result = writer
+            .edit(EditNoteParams {
+                path: "note.md".into(),
+                content: "".into(),
+                mode: EditMode::Append,
+                target_heading: None,
+                old_text: None,
+            })
+            .await;
+
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("empty"));
+    }
+}

--- a/crates/writer/src/resolve.rs
+++ b/crates/writer/src/resolve.rs
@@ -1,0 +1,247 @@
+use anyhow::{bail, Result};
+use kajet_core::traits::DocumentStore;
+use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+
+/// A resolved note path (both relative and absolute).
+#[derive(Debug, Clone)]
+pub struct ResolvedPath {
+    pub relative: String,
+    pub absolute: PathBuf,
+}
+
+/// Resolve a note path within the vault using a 3-step strategy:
+///
+/// 1. Exact filesystem match (try as-is, then with `.md` suffix)
+/// 2. Fuzzy suffix match via DocumentStore index
+/// 3. Filesystem walk fallback for unindexed files
+pub async fn resolve_note_path(
+    target: &str,
+    vault_path: &Path,
+    doc_store: Option<&Arc<dyn DocumentStore>>,
+) -> Result<ResolvedPath> {
+    // Reject path traversal
+    let normalized = target.replace('\\', "/");
+    let path = Path::new(&normalized);
+    for component in path.components() {
+        if matches!(component, Component::ParentDir) {
+            bail!(
+                "Path traversal rejected: '{}' contains '..' component",
+                target
+            );
+        }
+        if matches!(component, Component::RootDir | Component::Prefix(_)) {
+            bail!("Absolute paths are not allowed: '{}'", target);
+        }
+    }
+
+    // Step 1: exact filesystem match
+    let candidates = if normalized.ends_with(".md") {
+        vec![normalized.clone()]
+    } else {
+        vec![normalized.clone(), format!("{normalized}.md")]
+    };
+
+    for candidate in &candidates {
+        let abs = vault_path.join(candidate);
+        if tokio::fs::metadata(&abs).await.is_ok() {
+            return Ok(ResolvedPath {
+                relative: candidate.clone(),
+                absolute: abs,
+            });
+        }
+    }
+
+    // Step 2: fuzzy via DocumentStore
+    if let Some(store) = doc_store {
+        if let Ok(docs) = store.get_all_documents().await {
+            let needle = normalized.to_lowercase();
+            let matches: Vec<_> = docs
+                .iter()
+                .filter(|d| {
+                    let path = d.source_file.to_lowercase();
+                    path == needle
+                        || path == format!("{needle}.md")
+                        || path.ends_with(&format!("/{needle}"))
+                        || path.ends_with(&format!("/{needle}.md"))
+                })
+                .collect();
+
+            match matches.len() {
+                1 => {
+                    let rel = matches[0].source_file.clone();
+                    let abs = vault_path.join(&rel);
+                    return Ok(ResolvedPath {
+                        relative: rel,
+                        absolute: abs,
+                    });
+                }
+                n if n > 1 => {
+                    let paths: Vec<_> = matches.iter().map(|d| d.source_file.as_str()).collect();
+                    bail!(
+                        "Ambiguous path '{}': {} matches found: {}",
+                        target,
+                        n,
+                        paths.join(", ")
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
+
+    // Step 3: filesystem walk
+    if let Some(found) = walk_for_filename(vault_path, &normalized).await? {
+        return Ok(found);
+    }
+
+    bail!("Note not found: '{}'", target)
+}
+
+/// Walk the vault directory looking for a file matching the given name.
+async fn walk_for_filename(vault_path: &Path, target: &str) -> Result<Option<ResolvedPath>> {
+    let vault = vault_path.to_path_buf();
+    let target = target.to_string();
+
+    tokio::task::spawn_blocking(move || {
+        use ignore::WalkBuilder;
+        use unicode_normalization::UnicodeNormalization;
+
+        let needle = if target.ends_with(".md") {
+            target.clone()
+        } else {
+            format!("{target}.md")
+        };
+        let needle_nfc: String = needle.nfc().collect();
+        let needle_lower = needle_nfc.to_lowercase();
+
+        let walker = WalkBuilder::new(&vault)
+            .hidden(true)
+            .git_ignore(false)
+            .build();
+
+        let mut matches = Vec::new();
+        for entry in walker.flatten() {
+            if !entry.file_type().is_some_and(|ft| ft.is_file()) {
+                continue;
+            }
+            let path = entry.path();
+            let file_name: String = path
+                .file_name()
+                .map(|n| n.to_string_lossy().nfc().collect::<String>())
+                .unwrap_or_default();
+            if file_name.to_lowercase() == needle_lower {
+                if let Ok(rel) = path.strip_prefix(&vault) {
+                    matches.push(ResolvedPath {
+                        relative: rel.to_string_lossy().to_string(),
+                        absolute: path.to_path_buf(),
+                    });
+                }
+            }
+        }
+
+        match matches.len() {
+            0 => Ok(None),
+            1 => Ok(Some(matches.into_iter().next().unwrap())),
+            n => anyhow::bail!(
+                "Ambiguous: {} files match '{}': {}",
+                n,
+                target,
+                matches
+                    .iter()
+                    .map(|m| m.relative.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ),
+        }
+    })
+    .await?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn resolve_exact_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = dir.path();
+        tokio::fs::write(vault.join("note.md"), "# Note")
+            .await
+            .unwrap();
+
+        let resolved = resolve_note_path("note.md", vault, None).await.unwrap();
+        assert_eq!(resolved.relative, "note.md");
+        assert!(resolved.absolute.exists());
+    }
+
+    #[tokio::test]
+    async fn resolve_without_extension() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = dir.path();
+        tokio::fs::write(vault.join("note.md"), "# Note")
+            .await
+            .unwrap();
+
+        let resolved = resolve_note_path("note", vault, None).await.unwrap();
+        assert_eq!(resolved.relative, "note.md");
+    }
+
+    #[tokio::test]
+    async fn resolve_nested_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let vault = dir.path();
+        tokio::fs::create_dir_all(vault.join("sub/folder"))
+            .await
+            .unwrap();
+        tokio::fs::write(vault.join("sub/folder/deep.md"), "# Deep")
+            .await
+            .unwrap();
+
+        let resolved = resolve_note_path("sub/folder/deep", vault, None)
+            .await
+            .unwrap();
+        assert_eq!(resolved.relative, "sub/folder/deep.md");
+    }
+
+    #[tokio::test]
+    async fn resolve_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let result = resolve_note_path("nonexistent", dir.path(), None).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not found"));
+    }
+
+    #[tokio::test]
+    async fn resolve_via_docstore() {
+        use kajet_core::traits::mocks::MockDocumentStore;
+        use kajet_core::types::Document;
+
+        let dir = tempfile::tempdir().unwrap();
+        let vault = dir.path();
+        tokio::fs::create_dir_all(vault.join("projects"))
+            .await
+            .unwrap();
+        tokio::fs::write(vault.join("projects/ideas.md"), "# Ideas")
+            .await
+            .unwrap();
+
+        let store = MockDocumentStore::new();
+        store.documents.lock().unwrap().push(Document {
+            source_file: "projects/ideas.md".into(),
+            full_text: "# Ideas".into(),
+            title: "Ideas".into(),
+            tags: vec![],
+            content_hash: "abc".into(),
+            last_modified: 0.0,
+            outgoing_links: vec![],
+            backlinks: vec![],
+        });
+
+        let store: Arc<dyn DocumentStore> = Arc::new(store);
+        let resolved = resolve_note_path("ideas", vault, Some(&store))
+            .await
+            .unwrap();
+        assert_eq!(resolved.relative, "projects/ideas.md");
+    }
+}

--- a/crates/writer/src/timestamp.rs
+++ b/crates/writer/src/timestamp.rs
@@ -1,0 +1,110 @@
+use anyhow::Result;
+use kajet_core::config::TimestampConfig;
+
+/// Format the current time according to the timestamp config.
+pub fn format_now(config: &TimestampConfig) -> Result<String> {
+    let format_str = match config.format.as_str() {
+        "iso8601" => "%Y-%m-%dT%H:%M:%S",
+        "date_only" => "%Y-%m-%d",
+        "obsidian" => "%Y-%m-%d %H:%M",
+        other => other, // custom strftime
+    };
+
+    match config.timezone.as_str() {
+        "local" => {
+            let now = chrono::Local::now();
+            Ok(now.format(format_str).to_string())
+        }
+        "UTC" | "utc" => {
+            let now = chrono::Utc::now();
+            Ok(now.format(format_str).to_string())
+        }
+        tz_name => {
+            let tz: chrono_tz::Tz = tz_name
+                .parse()
+                .map_err(|_| anyhow::anyhow!("Unknown timezone: '{tz_name}'"))?;
+            let now = chrono::Utc::now().with_timezone(&tz);
+            Ok(now.format(format_str).to_string())
+        }
+    }
+}
+
+/// Validate that a timezone string is recognizable.
+pub fn validate_timezone(tz: &str) -> Result<()> {
+    match tz {
+        "local" | "UTC" | "utc" => Ok(()),
+        other => {
+            let _: chrono_tz::Tz = other
+                .parse()
+                .map_err(|_| anyhow::anyhow!("Unknown timezone: '{other}'"))?;
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_config() -> TimestampConfig {
+        TimestampConfig::default()
+    }
+
+    #[test]
+    fn format_now_local() {
+        let result = format_now(&default_config()).unwrap();
+        // ISO 8601-like format
+        assert!(result.contains('T'), "Should contain T separator: {result}");
+        assert!(result.len() >= 19, "Should be at least 19 chars: {result}");
+    }
+
+    #[test]
+    fn format_now_utc() {
+        let mut config = default_config();
+        config.timezone = "UTC".into();
+        let result = format_now(&config).unwrap();
+        assert!(result.contains('T'));
+    }
+
+    #[test]
+    fn format_now_iana_timezone() {
+        let mut config = default_config();
+        config.timezone = "Europe/Warsaw".into();
+        let result = format_now(&config).unwrap();
+        assert!(result.contains('T'));
+    }
+
+    #[test]
+    fn format_now_date_only() {
+        let mut config = default_config();
+        config.format = "date_only".into();
+        let result = format_now(&config).unwrap();
+        assert!(!result.contains('T'));
+        assert_eq!(result.len(), 10); // YYYY-MM-DD
+    }
+
+    #[test]
+    fn format_now_obsidian() {
+        let mut config = default_config();
+        config.format = "obsidian".into();
+        let result = format_now(&config).unwrap();
+        assert!(result.contains(' '));
+        assert!(!result.contains('T'));
+    }
+
+    #[test]
+    fn format_now_invalid_timezone() {
+        let mut config = default_config();
+        config.timezone = "Fake/Zone".into();
+        assert!(format_now(&config).is_err());
+    }
+
+    #[test]
+    fn validate_known_timezones() {
+        assert!(validate_timezone("local").is_ok());
+        assert!(validate_timezone("UTC").is_ok());
+        assert!(validate_timezone("Europe/Warsaw").is_ok());
+        assert!(validate_timezone("America/New_York").is_ok());
+        assert!(validate_timezone("Fake/Zone").is_err());
+    }
+}

--- a/crates/writer/src/types.rs
+++ b/crates/writer/src/types.rs
@@ -1,0 +1,107 @@
+use std::fmt;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+/// Parameters for creating a new note.
+#[derive(Debug, Clone)]
+pub struct CreateNoteParams {
+    /// Relative path within the vault, e.g. "Projects/ideas.md"
+    pub target: String,
+    /// Markdown body content
+    pub content: String,
+    /// Tags to include in frontmatter
+    pub tags: Vec<String>,
+    /// Aliases for the note (alternative names used by Obsidian for linking)
+    pub aliases: Vec<String>,
+}
+
+/// Parameters for editing an existing note.
+#[derive(Debug, Clone)]
+pub struct EditNoteParams {
+    /// Path to the note (exact, partial, or fuzzy)
+    pub path: String,
+    /// New content to insert/replace with
+    pub content: String,
+    /// Edit mode
+    pub mode: EditMode,
+    /// Target heading for section-level operations
+    pub target_heading: Option<String>,
+    /// Old text for replace_text mode
+    pub old_text: Option<String>,
+}
+
+/// Edit mode for edit_note.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum EditMode {
+    Append,
+    Prepend,
+    Overwrite,
+    ReplaceSection,
+    ReplaceText,
+    InsertAfter,
+}
+
+impl FromStr for EditMode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "append" => Ok(Self::Append),
+            "prepend" => Ok(Self::Prepend),
+            "overwrite" => Ok(Self::Overwrite),
+            "replace_section" => Ok(Self::ReplaceSection),
+            "replace_text" => Ok(Self::ReplaceText),
+            "insert_after" => Ok(Self::InsertAfter),
+            other => Err(format!("unknown edit mode: '{other}'")),
+        }
+    }
+}
+
+impl fmt::Display for EditMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl EditMode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Append => "append",
+            Self::Prepend => "prepend",
+            Self::Overwrite => "overwrite",
+            Self::ReplaceSection => "replace_section",
+            Self::ReplaceText => "replace_text",
+            Self::InsertAfter => "insert_after",
+        }
+    }
+
+    pub fn is_destructive(&self) -> bool {
+        matches!(
+            self,
+            Self::Overwrite | Self::ReplaceSection | Self::ReplaceText
+        )
+    }
+
+    /// Modes that require `old_text` parameter.
+    pub fn requires_old_text(&self) -> bool {
+        matches!(self, Self::ReplaceText | Self::InsertAfter)
+    }
+}
+
+/// Result of creating a note.
+#[derive(Debug, Clone)]
+pub struct CreateNoteResult {
+    pub path: String,
+    pub absolute_path: PathBuf,
+    pub bytes_written: usize,
+}
+
+/// Result of editing a note.
+#[derive(Debug, Clone)]
+pub struct EditNoteResult {
+    pub path: String,
+    pub absolute_path: PathBuf,
+    pub mode: String,
+    pub bytes_written: usize,
+    pub backup_path: Option<PathBuf>,
+}

--- a/locales/en.toml
+++ b/locales/en.toml
@@ -87,6 +87,14 @@ examine_backlinks = "Backlinks (%{count}):"
 examine_no_links = "none"
 examine_content_info = "Content: %{shown}/%{total} chars"
 
+# MCP — create_note / edit_note tools
+create_note_success = "Created note: %{path} (%{bytes} bytes)"
+create_note_failed = "Failed to create note: %{error}"
+edit_note_success = "Edited note: %{path} (mode: %{mode}, %{bytes} bytes)"
+edit_note_failed = "Failed to edit note: %{error}"
+edit_note_invalid_mode = "Invalid mode: '%{mode}'. Valid: append, prepend, overwrite, replace_section, replace_text, insert_after"
+edit_note_backup_created = "Backup created"
+
 # MCP — list_tags tool
 list_tags_header = "Tags (%{count} unique):"
 list_tags_empty = "No tags found"

--- a/locales/pl.toml
+++ b/locales/pl.toml
@@ -87,6 +87,14 @@ examine_backlinks = "Backlinki (%{count}):"
 examine_no_links = "brak"
 examine_content_info = "Treść: %{shown}/%{total} znaków"
 
+# MCP — narzędzia create_note / edit_note
+create_note_success = "Utworzono notatkę: %{path} (%{bytes} bajtów)"
+create_note_failed = "Nie udało się utworzyć notatki: %{error}"
+edit_note_success = "Edytowano notatkę: %{path} (tryb: %{mode}, %{bytes} bajtów)"
+edit_note_failed = "Nie udało się edytować notatki: %{error}"
+edit_note_invalid_mode = "Nieprawidłowy tryb: '%{mode}'. Dostępne: append, prepend, overwrite, replace_section, replace_text, insert_after"
+edit_note_backup_created = "Kopia zapasowa utworzona"
+
 # MCP — narzędzie list_tags
 list_tags_header = "Tagi (%{count} unikalnych):"
 list_tags_empty = "Nie znaleziono tagów"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,21 +1,20 @@
 [workspace]
 publish = false
-git_release_enable = true
-git_release_type = "auto"
-git_release_draft = false
-git_tag_name = "{{ package }}-v{{ version }}"
-git_release_name = "{{ package }} v{{ version }}"
 changelog_path = "./CHANGELOG.md"
-release_always = false
 dependencies_update = true
 semver_check = false
+release_always = false
 repo_url = "https://github.com/jpalczewski/kajet"
 pr_labels = ["🚀 release"]
+
+# Disable git releases/tags for all packages by default
+git_release_enable = false
+git_tag_enable = false
 
 [changelog]
 header = """# 📝 Changelog\n\nAll notable changes to this project will be documented in this file.\n"""
 body = """
-## `{{ package }}` - [{{ version }}]{% if release_link %}({{ release_link }}){% endif %} - {{ timestamp | date(format="%Y-%m-%d") }}
+## [{{ version }}]{% if release_link %}({{ release_link }}){% endif %} - {{ timestamp | date(format="%Y-%m-%d") }}
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group }}
 {% for commit in commits %}
@@ -42,39 +41,47 @@ commit_preprocessors = [
     { pattern = "\\(#([0-9]+)\\)", replace = "([#${1}](https://github.com/jpalczewski/kajet/pull/${1}))" },
 ]
 
-# Only create GitHub releases for the main kajet package
-[[package]]
-name = "kajet-parser"
-git_release_enable = false
-git_tag_enable = false
-
+# All crates share one version — version_group keeps them in sync
 [[package]]
 name = "kajet-core"
-git_release_enable = false
-git_tag_enable = false
+version_group = "kajet"
+changelog_update = false
+
+[[package]]
+name = "kajet-parser"
+version_group = "kajet"
+changelog_update = false
 
 [[package]]
 name = "kajet-backend"
-git_release_enable = false
-git_tag_enable = false
+version_group = "kajet"
+changelog_update = false
 
 [[package]]
 name = "kajet-indexer"
-git_release_enable = false
-git_tag_enable = false
+version_group = "kajet"
+changelog_update = false
 
 [[package]]
 name = "kajet-mcp"
-git_release_enable = false
-git_tag_enable = false
+version_group = "kajet"
+changelog_update = false
 
 [[package]]
 name = "kajet-web"
-git_release_enable = false
-git_tag_enable = false
+version_group = "kajet"
+changelog_update = false
 
 [[package]]
+name = "kajet-writer"
+version_group = "kajet"
+changelog_update = false
+
+# Root package — the only one with git tag/release and changelog
+[[package]]
 name = "kajet"
+version_group = "kajet"
+changelog_update = true
 git_release_enable = true
 git_tag_enable = true
 git_tag_name = "v{{ version }}"

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,7 +173,8 @@ async fn main() -> Result<()> {
                     Ok(_watcher) => {
                         let watcher_indexer = idx_state.indexer.clone();
                         let watcher_state = idx_state.clone();
-                        let watcher_vault = vault.to_path_buf();
+                        let watcher_vault =
+                            vault.canonicalize().unwrap_or_else(|_| vault.to_path_buf());
                         tokio::spawn(async move {
                             let _watcher = _watcher;
                             while let Some(changed_paths) = watch_rx.recv().await {


### PR DESCRIPTION
## Summary

Closes #43, closes #44, closes #45

- **kajet-writer crate**: `NoteWriter` with `create`/`edit` operations, path traversal & symlink protection, backup system, configurable timestamps
- **kajet-parser**: sections module (heading-aware parsing), transforms module (append/prepend/overwrite/replace_section/replace_text/insert_after)
- **MCP tools**: `create_note` and `edit_note` wired through schema → writer → parser

### Bugfixes
- **replace_section** ate blank line before next heading — fixed with separator before remainder
- **append + target_heading** inserted extra blank line between existing and new content — fixed by trimming trailing whitespace from body before insert
- **insert_after** content appended to same line as anchor — fixed with automatic newline handling
- **Duplicate timestamps**: `edit` used upsert (`update_frontmatter_field`) which added `modified:` even to notes with `Data aktualizacji:` from Obsidian — switched to `update_existing_frontmatter_field` (update-only, no insert)
- **File watcher silent failures**: FSEvents returns canonical paths, but `strip_prefix` used non-canonical vault path — fixed with `canonicalize()`

### New features
- `insert_after` edit mode: insert content after exact text anchor
- `aliases` parameter in `create_note` for Obsidian linking
- Configurable timestamp fields: empty field name disables that field
- Immediate reindex after create/edit (no reliance on file watcher)

### Chore
- Unified versioning: single semver/changelog for whole repo via `version_group`

## Test plan
- [x] `cargo nextest run -p kajet-parser` — 106 tests pass
- [x] `cargo nextest run -p kajet-writer` — 28 tests pass  
- [x] `cargo nextest run -p kajet-mcp` — 14 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Lefthook pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)