### PR TITLE
fix: writer/editor bugfixes and edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 [package]
 name = "kajet"
 version = "0.2.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 kajet-core = { path = "crates/core" }

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kajet-backend"
 version = "0.2.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 kajet-core = { path = "../core" }

--- a/crates/backend/src/embedder.rs
+++ b/crates/backend/src/embedder.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use candle_core::{Device, Tensor};
 use candle_nn::VarBuilder;
 use candle_transformers::models::bert::{BertModel, Config, DTYPE};
-use hf_hub::{api::sync::Api, Repo, RepoType};
+use hf_hub::{Repo, RepoType, api::sync::Api};
 use kajet_core::traits::Embedder;
 use std::sync::Mutex;
 use tokenizers::{PaddingParams, PaddingStrategy, Tokenizer};

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kajet-core"
 version = "0.2.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::path::Path;

--- a/crates/core/src/engine.rs
+++ b/crates/core/src/engine.rs
@@ -83,8 +83,8 @@ impl Engine {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::traits::mocks::{MockEmbedder, MockVectorStore};
     use crate::traits::SearchHit;
+    use crate::traits::mocks::{MockEmbedder, MockVectorStore};
     use std::sync::Arc;
 
     fn make_test_chunks() -> Vec<Chunk> {

--- a/crates/core/src/logging/file_layer.rs
+++ b/crates/core/src/logging/file_layer.rs
@@ -45,10 +45,10 @@ where
         _ctx: tracing_subscriber::layer::Context<'_, S>,
     ) {
         let entry = event_to_log_entry(event);
-        if let Ok(json) = serde_json::to_string(&entry) {
-            if let Ok(mut writer) = self.writer.lock() {
-                let _ = writeln!(writer, "{json}");
-            }
+        if let Ok(json) = serde_json::to_string(&entry)
+            && let Ok(mut writer) = self.writer.lock()
+        {
+            let _ = writeln!(writer, "{json}");
         }
     }
 }

--- a/crates/core/src/logging/mod.rs
+++ b/crates/core/src/logging/mod.rs
@@ -74,11 +74,7 @@ pub fn parse_level(s: &str) -> Level {
 /// Effective level = max(global, sink), i.e. the less verbose of the two.
 /// tracing `Level` ordering: ERROR < WARN < INFO < DEBUG < TRACE.
 pub fn effective_level(global: Level, sink: Level) -> Level {
-    if global < sink {
-        global
-    } else {
-        sink
-    }
+    if global < sink { global } else { sink }
 }
 
 /// Convert a tracing event into a `LogEntry`.

--- a/crates/core/src/search.rs
+++ b/crates/core/src/search.rs
@@ -275,8 +275,8 @@ fn merge_results(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::traits::mocks::{MockDocumentStore, MockEmbedder, MockVectorStore};
     use crate::traits::SearchHit;
+    use crate::traits::mocks::{MockDocumentStore, MockEmbedder, MockVectorStore};
     use crate::types::FtsHit;
 
     fn make_search_engine(

--- a/crates/indexer/Cargo.toml
+++ b/crates/indexer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kajet-indexer"
 version = "0.2.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 kajet-core = { path = "../core" }

--- a/crates/indexer/Cargo.toml
+++ b/crates/indexer/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.0"
 edition = "2021"
 
 [dependencies]
-kajet-core = { path = "../core", features = ["test-utils"] }
+kajet-core = { path = "../core" }
 kajet-parser = { path = "../parser" }
 kajet-backend = { path = "../backend" }
 
@@ -18,5 +18,6 @@ ignore = "0.4"
 unicode-normalization = "0.1"
 
 [dev-dependencies]
+kajet-core = { path = "../core", features = ["test-utils"] }
 tokio = { version = "1", features = ["test-util", "macros", "rt-multi-thread"] }
 tempfile = "3"

--- a/crates/indexer/src/changes.rs
+++ b/crates/indexer/src/changes.rs
@@ -40,10 +40,10 @@ pub fn detect_changes(
 
             if path.is_dir() {
                 let name = path.file_name().map(|n| n.to_string_lossy().to_string());
-                if let Some(name) = name {
-                    if excludes.iter().any(|f| f == &name) {
-                        return ignore::WalkState::Skip;
-                    }
+                if let Some(name) = name
+                    && excludes.iter().any(|f| f == &name)
+                {
+                    return ignore::WalkState::Skip;
                 }
                 return ignore::WalkState::Continue;
             }
@@ -75,16 +75,16 @@ pub fn detect_changes(
             }
             Some(stored_info) => {
                 // Fast path: check mtime via metadata (no file read needed)
-                if let Ok(metadata) = std::fs::metadata(&abs_path) {
-                    if let Ok(modified) = metadata.modified() {
-                        let mtime = modified
-                            .duration_since(std::time::UNIX_EPOCH)
-                            .unwrap_or_default()
-                            .as_secs_f64();
-                        if (mtime - stored_info.last_modified).abs() < 1.0 {
-                            tracing::debug!(path = %rel_path, "file:skip");
-                            continue;
-                        }
+                if let Ok(metadata) = std::fs::metadata(&abs_path)
+                    && let Ok(modified) = metadata.modified()
+                {
+                    let mtime = modified
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .unwrap_or_default()
+                        .as_secs_f64();
+                    if (mtime - stored_info.last_modified).abs() < 1.0 {
+                        tracing::debug!(path = %rel_path, "file:skip");
+                        continue;
                     }
                 }
                 // Slow path: mtime changed, read + hash to confirm

--- a/crates/indexer/src/pipeline.rs
+++ b/crates/indexer/src/pipeline.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
-use tokio::sync::{mpsc, Semaphore};
+use tokio::sync::{Semaphore, mpsc};
 use unicode_normalization::UnicodeNormalization;
 
 /// Result of processing a single file through the pipeline.

--- a/crates/indexer/src/watcher.rs
+++ b/crates/indexer/src/watcher.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use notify::RecursiveMode;
-use notify_debouncer_full::{new_debouncer, DebounceEventResult, Debouncer, RecommendedCache};
+use notify_debouncer_full::{DebounceEventResult, Debouncer, RecommendedCache, new_debouncer};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tokio::sync::mpsc;

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kajet-mcp"
 version = "0.2.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 kajet-core = { path = "../core" }

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -19,8 +19,8 @@ pub use schema::{
 use anyhow::Result;
 use kajet_core::types::AppState;
 use rmcp::{
-    handler::server::router::tool::ToolRouter, model::*, tool_handler, transport::stdio,
-    ServerHandler, ServiceExt,
+    ServerHandler, ServiceExt, handler::server::router::tool::ToolRouter, model::*, tool_handler,
+    transport::stdio,
 };
 use std::sync::Arc;
 

--- a/crates/parser/Cargo.toml
+++ b/crates/parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kajet-parser"
 version = "0.2.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 ignore = "0.4"

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -12,10 +12,10 @@ pub use frontmatter::{
     extract_tags, extract_title, generate_frontmatter, strip_frontmatter,
     update_existing_frontmatter_field, update_frontmatter_field,
 };
-pub use sections::{find_section_by_heading, parse_sections, Section, SectionLookupError};
+pub use sections::{Section, SectionLookupError, find_section_by_heading, parse_sections};
 pub use transforms::{
-    append_content, insert_after, overwrite_body, prepend_content, replace_section, replace_text,
-    MatchPosition, ReplaceError, TransformError,
+    MatchPosition, ReplaceError, TransformError, append_content, insert_after, overwrite_body,
+    prepend_content, replace_section, replace_text,
 };
 pub use types::{Chunk, ChunkConfig, Link, ParsedDocument};
 pub use vault::{parse_vault, parse_vault_entries, parse_vault_entries_with_config, scan_vault};

--- a/crates/parser/src/transforms.rs
+++ b/crates/parser/src/transforms.rs
@@ -1,5 +1,5 @@
 use crate::frontmatter::strip_frontmatter;
-use crate::sections::{find_section_by_heading, parse_sections, SectionLookupError};
+use crate::sections::{SectionLookupError, find_section_by_heading, parse_sections};
 
 /// Errors from section-based transforms.
 #[derive(Debug, Clone)]

--- a/crates/parser/src/vault.rs
+++ b/crates/parser/src/vault.rs
@@ -42,10 +42,10 @@ pub fn scan_vault(
             // Skip excluded folders
             if path.is_dir() {
                 let name = path.file_name().map(|n| n.to_string_lossy().to_string());
-                if let Some(name) = name {
-                    if excludes.iter().any(|f| f == &name) {
-                        return ignore::WalkState::Skip;
-                    }
+                if let Some(name) = name
+                    && excludes.iter().any(|f| f == &name)
+                {
+                    return ignore::WalkState::Skip;
                 }
                 return ignore::WalkState::Continue;
             }

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kajet-web"
 version = "0.2.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 kajet-core = { path = "../core" }

--- a/crates/web/build.rs
+++ b/crates/web/build.rs
@@ -27,7 +27,9 @@ fn main() {
             );
         }
         Err(_) => {
-            eprintln!("cargo:warning=deno not found. Run `cd frontend && deno install && deno task build` manually");
+            eprintln!(
+                "cargo:warning=deno not found. Run `cd frontend && deno install && deno task build` manually"
+            );
         }
     }
 }

--- a/crates/web/src/lib.rs
+++ b/crates/web/src/lib.rs
@@ -4,14 +4,14 @@ extern crate rust_i18n;
 i18n!("../../locales", fallback = "en");
 
 use axum::{
+    Router,
     extract::{
-        ws::{Message, WebSocket, WebSocketUpgrade},
         Query, State,
+        ws::{Message, WebSocket, WebSocketUpgrade},
     },
-    http::{header, StatusCode},
+    http::{StatusCode, header},
     response::{IntoResponse, Json},
     routing::{get, put},
-    Router,
 };
 use kajet_core::logging::types::WsMessage;
 use kajet_core::types::AppState;
@@ -52,16 +52,16 @@ async fn serve_spa(uri: axum::http::Uri) -> impl IntoResponse {
     let path = uri.path().trim_start_matches('/');
 
     // Try to serve the exact file first
-    if !path.is_empty() {
-        if let Some(file) = Assets::get(path) {
-            let mime = mime_guess::from_path(path).first_or_octet_stream();
-            return (
-                StatusCode::OK,
-                [(header::CONTENT_TYPE, mime.as_ref().to_string())],
-                file.data.to_vec(),
-            )
-                .into_response();
-        }
+    if !path.is_empty()
+        && let Some(file) = Assets::get(path)
+    {
+        let mime = mime_guess::from_path(path).first_or_octet_stream();
+        return (
+            StatusCode::OK,
+            [(header::CONTENT_TYPE, mime.as_ref().to_string())],
+            file.data.to_vec(),
+        )
+            .into_response();
     }
 
     // Fallback to index.html for SPA routing

--- a/crates/writer/Cargo.toml
+++ b/crates/writer/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.2.0"
 edition = "2021"
 
 [dependencies]
-kajet-core = { path = "../core", features = ["test-utils"] }
+kajet-core = { path = "../core" }
 kajet-parser = { path = "../parser" }
 anyhow = "1"
 chrono = { version = "0.4", features = ["serde"] }
@@ -15,5 +15,6 @@ unicode-normalization = "0.1"
 ignore = "0.4"
 
 [dev-dependencies]
+kajet-core = { path = "../core", features = ["test-utils"] }
 tokio = { version = "1", features = ["test-util", "macros", "fs", "rt-multi-thread"] }
 tempfile = "3"

--- a/crates/writer/Cargo.toml
+++ b/crates/writer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kajet-writer"
 version = "0.2.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 kajet-core = { path = "../core" }

--- a/crates/writer/src/lib.rs
+++ b/crates/writer/src/lib.rs
@@ -5,7 +5,7 @@ pub mod types;
 
 pub use types::{CreateNoteParams, CreateNoteResult, EditMode, EditNoteParams, EditNoteResult};
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use kajet_core::config::WriterConfig;
 use kajet_core::traits::DocumentStore;
 use std::path::{Component, Path, PathBuf};

--- a/crates/writer/src/resolve.rs
+++ b/crates/writer/src/resolve.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use kajet_core::traits::DocumentStore;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
@@ -53,40 +53,40 @@ pub async fn resolve_note_path(
     }
 
     // Step 2: fuzzy via DocumentStore
-    if let Some(store) = doc_store {
-        if let Ok(docs) = store.get_all_documents().await {
-            let needle = normalized.to_lowercase();
-            let matches: Vec<_> = docs
-                .iter()
-                .filter(|d| {
-                    let path = d.source_file.to_lowercase();
-                    path == needle
-                        || path == format!("{needle}.md")
-                        || path.ends_with(&format!("/{needle}"))
-                        || path.ends_with(&format!("/{needle}.md"))
-                })
-                .collect();
+    if let Some(store) = doc_store
+        && let Ok(docs) = store.get_all_documents().await
+    {
+        let needle = normalized.to_lowercase();
+        let matches: Vec<_> = docs
+            .iter()
+            .filter(|d| {
+                let path = d.source_file.to_lowercase();
+                path == needle
+                    || path == format!("{needle}.md")
+                    || path.ends_with(&format!("/{needle}"))
+                    || path.ends_with(&format!("/{needle}.md"))
+            })
+            .collect();
 
-            match matches.len() {
-                1 => {
-                    let rel = matches[0].source_file.clone();
-                    let abs = vault_path.join(&rel);
-                    return Ok(ResolvedPath {
-                        relative: rel,
-                        absolute: abs,
-                    });
-                }
-                n if n > 1 => {
-                    let paths: Vec<_> = matches.iter().map(|d| d.source_file.as_str()).collect();
-                    bail!(
-                        "Ambiguous path '{}': {} matches found: {}",
-                        target,
-                        n,
-                        paths.join(", ")
-                    );
-                }
-                _ => {}
+        match matches.len() {
+            1 => {
+                let rel = matches[0].source_file.clone();
+                let abs = vault_path.join(&rel);
+                return Ok(ResolvedPath {
+                    relative: rel,
+                    absolute: abs,
+                });
             }
+            n if n > 1 => {
+                let paths: Vec<_> = matches.iter().map(|d| d.source_file.as_str()).collect();
+                bail!(
+                    "Ambiguous path '{}': {} matches found: {}",
+                    target,
+                    n,
+                    paths.join(", ")
+                );
+            }
+            _ => {}
         }
     }
 
@@ -130,13 +130,13 @@ async fn walk_for_filename(vault_path: &Path, target: &str) -> Result<Option<Res
                 .file_name()
                 .map(|n| n.to_string_lossy().nfc().collect::<String>())
                 .unwrap_or_default();
-            if file_name.to_lowercase() == needle_lower {
-                if let Ok(rel) = path.strip_prefix(&vault) {
-                    matches.push(ResolvedPath {
-                        relative: rel.to_string_lossy().to_string(),
-                        absolute: path.to_path_buf(),
-                    });
-                }
+            if file_name.to_lowercase() == needle_lower
+                && let Ok(rel) = path.strip_prefix(&vault)
+            {
+                matches.push(ResolvedPath {
+                    relative: rel.to_string_lossy().to_string(),
+                    absolute: path.to_path_buf(),
+                });
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,8 @@ use anyhow::Result;
 use clap::Parser;
 use kajet_core::logging::types::LogEntry;
 use kajet_core::types::{AppState, QueryEvent};
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use tokio::sync::{broadcast, mpsc};
 use unicode_normalization::UnicodeNormalization;
 


### PR DESCRIPTION
## Summary
- Add `create_note`/`edit_note` MCP tools with path traversal/symlink protection, timestamps, and backups
- Fix empty frontmatter panic in `update_frontmatter_field` / `update_existing_frontmatter_field`
- Fix symlink directory escape: move vault boundary check before `create_dir_all`
- Move `test-utils` feature from `[dependencies]` to `[dev-dependencies]` in writer and indexer (prevents mock code in release binary)
- Bump Rust edition to 2024 across all workspace crates
- Unify versioning to single semver/changelog for the whole repo

## Test plan
- [x] 219/219 workspace tests passing
- [x] Clippy clean (`-D warnings`)
- [x] `cargo fmt --check` clean
- [x] Lefthook pre-commit hooks passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)