### PR TITLE
fix(ci): quote if expression in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   prepare-release:
     name: Create Release PR
-    if: ${{ github.event_name == 'push' && !contains(github.event.head_commit.message, 'chore: prepare release') }}
+    if: "github.event_name == 'push' && !contains(github.event.head_commit.message, 'chore: prepare release')"
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Fix YAML parsing error: `!contains()` was interpreted as a YAML tag, quoted the `if:` expression as a string

## Test plan
- [x] Valid GitHub Actions YAML syntax

🤖 Generated with [Claude Code](https://claude.com/claude-code)