### PR TITLE
fix(ci): update knope-dev/action to v2.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
-      - uses: knope-dev/action@v2.0.0
+      - uses: knope-dev/action@v2.1.0
         with:
           version: 0.22.2
       - run: knope prepare-release --verbose
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: knope-dev/action@v2.0.0
+      - uses: knope-dev/action@v2.1.0
         with:
           version: 0.22.2
       - run: knope release --verbose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           git config --global user.name "GitHub Actions"
           git config --global user.email "actions@github.com"
-      - uses: knope-dev/action@v2
+      - uses: knope-dev/action@v2.0.0
         with:
           version: 0.22.2
       - run: knope prepare-release --verbose
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: knope-dev/action@v2
+      - uses: knope-dev/action@v2.0.0
         with:
           version: 0.22.2
       - run: knope release --verbose


### PR DESCRIPTION
## Summary
- Fix GitHub Actions error: use `knope-dev/action@v2.1.0` (latest version) instead of `@v2`

## Test plan
- [x] Valid GitHub Actions workflow with correct action version

🤖 Generated with [Claude Code](https://claude.com/claude-code)