### PR TITLE
feat: batch examine multiple paths in one request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3685,14 +3685,12 @@ dependencies = [
  "kajet-core",
  "kajet-indexer",
  "kajet-mcp",
- "kajet-parser",
  "kajet-remote",
  "kajet-web",
  "open",
  "rust-i18n",
  "tokio",
  "tracing",
- "tracing-subscriber",
  "unicode-normalization",
 ]
 
@@ -3742,7 +3740,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "ts-rs",
- "uuid",
  "xxhash-rust",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3698,7 +3698,7 @@ dependencies = [
 
 [[package]]
 name = "kajet-backend"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -3725,7 +3725,7 @@ dependencies = [
 
 [[package]]
 name = "kajet-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3748,7 +3748,7 @@ dependencies = [
 
 [[package]]
 name = "kajet-indexer"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3766,7 +3766,7 @@ dependencies = [
 
 [[package]]
 name = "kajet-mcp"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3786,7 +3786,7 @@ dependencies = [
 
 [[package]]
 name = "kajet-parser"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3818,7 +3818,7 @@ dependencies = [
 
 [[package]]
 name = "kajet-web"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3844,7 +3844,7 @@ dependencies = [
 
 [[package]]
 name = "kajet-writer"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ edition = "2024"
 
 [dependencies]
 kajet-core = { path = "crates/core" }
-kajet-parser = { path = "crates/parser" }
 kajet-backend = { path = "crates/backend" }
 kajet-remote = { path = "crates/remote" }
 kajet-indexer = { path = "crates/indexer" }
@@ -26,7 +25,6 @@ kajet-web = { path = "crates/web" }
 
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 open = "5"

--- a/agents.md
+++ b/agents.md
@@ -54,6 +54,8 @@ kajet-web           — Axum HTTP + WebSocket, embedded Svelte frontend (rust-em
 - pulldown-cmark `End(TagEnd::Item)` doesn't emit whitespace — chunker must add `\n` after list items.
 - Embedder model cached in `~/.cache/huggingface/`, auto-downloaded via hf-hub on first run.
 - **LanceDB type consistency:** Schema definition, write array, and read downcast must use matching types. Example: `DataType::Int64` → `Int64Array::from` → `.downcast_ref::<Int64Array>()`. Mismatches fail at runtime ("invalid type"), not compile time.
+- **Path handling must be centralized:** For folder-prefix/path membership checks, use `kajet_core::path_utils` (`normalize_folder_prefix`, `path_matches_folder_prefix`) instead of ad-hoc `starts_with` logic. If a needed path helper is missing (e.g. normalization/validation), add it to `kajet-core` and reuse it.
+- **File-touching modules to keep aligned with core path utils:** `crates/indexer/src/lib.rs`, `crates/indexer/src/changes.rs`, `crates/indexer/src/pipeline.rs`, `crates/parser/src/vault.rs`, `crates/writer/src/resolve.rs`, `crates/web/src/lib.rs`.
 
 ## Code Style
 
@@ -64,6 +66,7 @@ kajet-web           — Axum HTTP + WebSocket, embedded Svelte frontend (rust-em
 - Use type system to prevent invalid states where practical (newtypes, enums over booleans, builder pattern for complex config).
 - `thiserror` for library crate errors, `anyhow` for application-level. Error context with `.context()` — never bare `.unwrap()` in non-test code.
 - `#[tracing::instrument]` with `skip(self)` on public methods.
+- Reuse shared helpers from `kajet-core` for cross-crate behavior (especially path filtering/normalization). Avoid copying path logic between `indexer`/`parser`/`writer`/`web`/`mcp`.
 
 **Logging levels (strict):**
 

--- a/crates/backend/Cargo.toml
+++ b/crates/backend/Cargo.toml
@@ -41,3 +41,6 @@ tempfile = "3"
 candle-core = { version = "0.9", features = ["metal"] }
 candle-nn = { version = "0.9", features = ["metal"] }
 candle-transformers = { version = "0.9", features = ["metal"] }
+
+[package.metadata.cargo-machete]
+ignored = ["lzma-sys"]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -19,7 +19,6 @@ dirs = "6"
 xxhash-rust = { version = "0.8", features = ["xxh3"] }
 rust-i18n = "3"
 ts-rs = { version = "11", features = ["serde-compat", "chrono-impl"] }
-uuid = { version = "1", features = ["v4"] }
 
 [features]
 test-utils = []

--- a/crates/core/src/search.rs
+++ b/crates/core/src/search.rs
@@ -11,6 +11,18 @@ pub struct ExamineResult {
     pub document: Document,
 }
 
+#[derive(Debug, Clone)]
+pub enum ExamineManyResult {
+    Success {
+        requested_path: String,
+        document: Document,
+    },
+    Error {
+        requested_path: String,
+        error: String,
+    },
+}
+
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct SearchResult {
     pub note_path: String,
@@ -148,36 +160,44 @@ impl SearchEngine {
 
         // 2. Fuzzy: suffix match on all documents
         let all_docs = self.doc_store.get_all_documents().await?;
-        let suffix = format!("/{path}");
-        let suffix_md = format!("/{path}.md");
+        let doc = fuzzy_match_examine_document(&all_docs, path)?;
+        Ok(ExamineResult {
+            document: doc.clone(),
+        })
+    }
 
-        let matches: Vec<&Document> = all_docs
+    /// Batch examine multiple documents by path with a single document fetch.
+    #[tracing::instrument(level = "debug", skip(self, paths), fields(paths_count = paths.len()))]
+    pub async fn examine_many(&self, paths: &[String]) -> Result<Vec<ExamineManyResult>> {
+        let all_docs = self.doc_store.get_all_documents().await?;
+        let exact_map: HashMap<&str, &Document> = all_docs
             .iter()
-            .filter(|d| {
-                d.source_file.ends_with(&suffix)
-                    || d.source_file == path
-                    || d.source_file.ends_with(&suffix_md)
-                    || d.source_file == format!("{path}.md")
-            })
+            .map(|doc| (doc.source_file.as_str(), doc))
             .collect();
 
-        match matches.len() {
-            0 => anyhow::bail!("{}", t!("examine_not_found", path = path)),
-            1 => Ok(ExamineResult {
-                document: matches[0].clone(),
-            }),
-            _ => {
-                let candidates = matches
-                    .iter()
-                    .map(|d| format!("  - {}", d.source_file))
-                    .collect::<Vec<_>>()
-                    .join("\n");
-                anyhow::bail!(
-                    "{}",
-                    t!("examine_ambiguous", path = path, candidates = candidates)
-                )
+        let mut out = Vec::with_capacity(paths.len());
+        for path in paths {
+            if let Some(doc) = exact_map.get(path.as_str()) {
+                out.push(ExamineManyResult::Success {
+                    requested_path: path.clone(),
+                    document: (*doc).clone(),
+                });
+                continue;
+            }
+
+            match fuzzy_match_examine_document(&all_docs, path) {
+                Ok(doc) => out.push(ExamineManyResult::Success {
+                    requested_path: path.clone(),
+                    document: doc.clone(),
+                }),
+                Err(error) => out.push(ExamineManyResult::Error {
+                    requested_path: path.clone(),
+                    error: error.to_string(),
+                }),
             }
         }
+
+        Ok(out)
     }
 
     /// Pure full-text search.
@@ -202,6 +222,38 @@ impl SearchEngine {
                 }
             })
             .collect())
+    }
+}
+
+fn fuzzy_match_examine_document<'a>(all_docs: &'a [Document], path: &str) -> Result<&'a Document> {
+    let suffix = format!("/{path}");
+    let suffix_md = format!("/{path}.md");
+    let path_md = format!("{path}.md");
+
+    let matches: Vec<&Document> = all_docs
+        .iter()
+        .filter(|d| {
+            d.source_file.ends_with(&suffix)
+                || d.source_file == path
+                || d.source_file.ends_with(&suffix_md)
+                || d.source_file == path_md
+        })
+        .collect();
+
+    match matches.len() {
+        0 => anyhow::bail!("{}", t!("examine_not_found", path = path)),
+        1 => Ok(matches[0]),
+        _ => {
+            let candidates = matches
+                .iter()
+                .map(|d| format!("  - {}", d.source_file))
+                .collect::<Vec<_>>()
+                .join("\n");
+            anyhow::bail!(
+                "{}",
+                t!("examine_ambiguous", path = path, candidates = candidates)
+            )
+        }
     }
 }
 
@@ -307,7 +359,7 @@ mod tests {
     use super::*;
     use crate::traits::SearchHit;
     use crate::traits::mocks::{MockDocumentStore, MockEmbedder, MockVectorStore};
-    use crate::types::FtsHit;
+    use crate::types::{Document, FtsHit};
 
     fn make_search_engine_with_embedder(
         embedder: Arc<dyn Embedder>,
@@ -330,6 +382,30 @@ mod tests {
             Arc::new(MockVectorStore::with_search_results(vector_results)),
             Arc::new(MockDocumentStore::with_fts_results(fts_results)),
         )
+    }
+
+    fn make_search_engine_with_docs(docs: Vec<Document>) -> SearchEngine {
+        let doc_store = Arc::new(MockDocumentStore::new());
+        doc_store.documents.lock().unwrap().extend(docs);
+
+        SearchEngine::new(
+            Arc::new(MockEmbedder::new(4)),
+            Arc::new(MockVectorStore::new()),
+            doc_store,
+        )
+    }
+
+    fn sample_doc(path: &str, title: &str) -> Document {
+        Document {
+            source_file: path.to_string(),
+            full_text: format!("content for {title}"),
+            title: title.to_string(),
+            tags: vec![],
+            content_hash: "hash".to_string(),
+            last_modified: 0.0,
+            outgoing_links: vec![],
+            backlinks: vec![],
+        }
     }
 
     #[tokio::test]
@@ -450,6 +526,54 @@ mod tests {
 
         // a.md should score highest (appears in both)
         assert_eq!(results[0].note_path, "a.md");
+    }
+
+    #[tokio::test]
+    async fn examine_many_returns_partial_success_in_order() {
+        let engine = make_search_engine_with_docs(vec![sample_doc("journal/demo.md", "Demo")]);
+        let results = engine
+            .examine_many(&["demo".to_string(), "missing.md".to_string()])
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 2);
+        match &results[0] {
+            ExamineManyResult::Success {
+                requested_path,
+                document,
+            } => {
+                assert_eq!(requested_path, "demo");
+                assert_eq!(document.source_file, "journal/demo.md");
+            }
+            ExamineManyResult::Error { .. } => panic!("expected success"),
+        }
+        match &results[1] {
+            ExamineManyResult::Error {
+                requested_path,
+                error,
+            } => {
+                assert_eq!(requested_path, "missing.md");
+                assert!(error.contains("Document not found"));
+            }
+            ExamineManyResult::Success { .. } => panic!("expected error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn examine_many_reports_ambiguous_path() {
+        let engine = make_search_engine_with_docs(vec![
+            sample_doc("journal/note.md", "Journal"),
+            sample_doc("projects/note.md", "Projects"),
+        ]);
+        let results = engine.examine_many(&["note.md".to_string()]).await.unwrap();
+
+        assert_eq!(results.len(), 1);
+        match &results[0] {
+            ExamineManyResult::Error { error, .. } => {
+                assert!(error.contains("Multiple matches"));
+            }
+            ExamineManyResult::Success { .. } => panic!("expected ambiguous error"),
+        }
     }
 
     #[test]

--- a/crates/indexer/src/lib.rs
+++ b/crates/indexer/src/lib.rs
@@ -3,13 +3,17 @@ mod embedding_worker;
 pub mod pipeline;
 pub mod watcher;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
+use ignore::WalkBuilder;
+use kajet_core::path_utils::{normalize_folder_prefix, path_matches_folder_prefix};
 use kajet_core::traits::{DocumentStore, Embedder, VectorStore};
 use kajet_core::types::{FileChange, IndexStats, IndexerHandle};
 use pipeline::IndexPipeline;
-use std::path::Path;
+use std::collections::{BTreeSet, HashSet};
+use std::path::{Component, Path};
 use std::sync::Arc;
 use std::time::Instant;
+use unicode_normalization::UnicodeNormalization;
 
 pub struct Indexer {
     embedder: Arc<dyn Embedder>,
@@ -21,6 +25,11 @@ pub struct Indexer {
     created_date_field: Option<String>,
     modified_date_field: Option<String>,
     document_prefix: String,
+}
+
+struct ReindexPlan {
+    delete_paths: Vec<String>,
+    reindex_paths: Vec<String>,
 }
 
 impl Indexer {
@@ -153,17 +162,39 @@ impl Indexer {
 
     /// Reindex specific files by their relative paths.
     pub async fn reindex_files(&self, vault_path: &Path, rel_paths: &[String]) -> Result<()> {
-        // Delete old data for these files
-        self.store.delete_chunks_by_paths(rel_paths).await?;
-        self.doc_store.delete_by_paths(rel_paths).await?;
+        let indexed_paths: HashSet<String> = self
+            .doc_store
+            .get_document_hashes()
+            .await?
+            .into_keys()
+            .collect();
 
-        // Build changes for files that still exist
-        let changes: Vec<FileChange> = rel_paths
+        let vault = vault_path.to_path_buf();
+        let requested_paths = rel_paths.to_vec();
+        let plan = tokio::task::spawn_blocking(move || {
+            build_reindex_plan(&vault, &requested_paths, &indexed_paths)
+        })
+        .await
+        .context("Failed to join reindex planning task")??;
+
+        tracing::info!(
+            requested = rel_paths.len(),
+            to_delete = plan.delete_paths.len(),
+            to_reindex = plan.reindex_paths.len(),
+            "Reindex paths resolved"
+        );
+
+        if !plan.delete_paths.is_empty() {
+            self.store
+                .delete_chunks_by_paths(&plan.delete_paths)
+                .await?;
+            self.doc_store.delete_by_paths(&plan.delete_paths).await?;
+        }
+
+        let changes: Vec<FileChange> = plan
+            .reindex_paths
             .iter()
-            .filter_map(|rel_path| {
-                let full_path = vault_path.join(rel_path);
-                full_path.exists().then_some(FileChange::Added(full_path))
-            })
+            .map(|rel_path| FileChange::Added(vault_path.join(rel_path)))
             .collect();
 
         if !changes.is_empty() {
@@ -207,6 +238,155 @@ fn categorize_changes(changes: &[FileChange]) -> (Vec<&Path>, Vec<&Path>, Vec<&s
     }
 
     (added, modified, deleted)
+}
+
+fn build_reindex_plan(
+    vault_path: &Path,
+    requested_paths: &[String],
+    indexed_paths: &HashSet<String>,
+) -> Result<ReindexPlan> {
+    let mut delete_paths: BTreeSet<String> = BTreeSet::new();
+    let mut reindex_paths: BTreeSet<String> = BTreeSet::new();
+
+    for raw_path in requested_paths {
+        let requested_path = raw_path.trim();
+        anyhow::ensure!(!requested_path.is_empty(), "Reindex path cannot be empty");
+        validate_relative_path(requested_path)?;
+
+        let normalized_requested = normalize_requested_path(requested_path);
+        let absolute_path = vault_path.join(requested_path);
+
+        if absolute_path.is_dir() {
+            for indexed in indexed_paths {
+                if is_within_folder(indexed, &normalized_requested) {
+                    delete_paths.insert(indexed.clone());
+                }
+            }
+
+            for rel in collect_markdown_paths(&absolute_path, vault_path)? {
+                delete_paths.insert(rel.clone());
+                reindex_paths.insert(rel);
+            }
+
+            continue;
+        }
+
+        if absolute_path.is_file() {
+            if absolute_path.extension().is_none_or(|ext| ext != "md") {
+                tracing::debug!(path = requested_path, "Skipping non-markdown reindex path");
+                continue;
+            }
+
+            let rel = normalize_relative_path(&absolute_path, vault_path)?;
+            delete_paths.insert(rel.clone());
+            reindex_paths.insert(rel);
+            continue;
+        }
+
+        let mut matched_index_prefix = false;
+        for indexed in indexed_paths {
+            if is_within_folder(indexed, &normalized_requested) {
+                delete_paths.insert(indexed.clone());
+                matched_index_prefix = true;
+            }
+        }
+
+        if !matched_index_prefix {
+            delete_paths.insert(normalized_requested);
+        }
+    }
+
+    Ok(ReindexPlan {
+        delete_paths: delete_paths.into_iter().collect(),
+        reindex_paths: reindex_paths.into_iter().collect(),
+    })
+}
+
+fn collect_markdown_paths(root: &Path, vault_path: &Path) -> Result<Vec<String>> {
+    let mut builder = WalkBuilder::new(root);
+    builder.standard_filters(true);
+
+    let mut rel_paths = BTreeSet::new();
+    for entry in builder.build() {
+        let entry = entry?;
+        if !entry.file_type().is_some_and(|ft| ft.is_file()) {
+            continue;
+        }
+
+        let path = entry.path();
+        if path.extension().is_none_or(|ext| ext != "md") {
+            continue;
+        }
+
+        rel_paths.insert(normalize_relative_path(path, vault_path)?);
+    }
+
+    Ok(rel_paths.into_iter().collect())
+}
+
+fn validate_relative_path(path: &str) -> Result<()> {
+    let candidate = Path::new(path);
+    anyhow::ensure!(
+        !candidate.is_absolute(),
+        "Reindex path must be relative to vault root: {path}"
+    );
+
+    for component in candidate.components() {
+        match component {
+            Component::ParentDir => anyhow::bail!(
+                "Reindex path cannot contain parent directory traversal ('..'): {path}"
+            ),
+            Component::Prefix(_) | Component::RootDir => {
+                anyhow::bail!("Reindex path must be relative to vault root: {path}")
+            }
+            Component::CurDir | Component::Normal(_) => {}
+        }
+    }
+
+    Ok(())
+}
+
+fn normalize_requested_path(path: &str) -> String {
+    Path::new(path)
+        .components()
+        .filter_map(|component| match component {
+            Component::CurDir => None,
+            Component::Normal(seg) => Some(seg.to_string_lossy().into_owned()),
+            Component::ParentDir | Component::Prefix(_) | Component::RootDir => None,
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+        .nfc()
+        .collect()
+}
+
+fn normalize_relative_path(path: &Path, vault_path: &Path) -> Result<String> {
+    let rel = path
+        .strip_prefix(vault_path)
+        .with_context(|| {
+            format!(
+                "Path '{}' is outside vault '{}'",
+                path.display(),
+                vault_path.display()
+            )
+        })?
+        .to_string_lossy()
+        .nfc()
+        .collect::<String>();
+
+    Ok(rel)
+}
+
+fn is_within_folder(path: &str, folder: &str) -> bool {
+    if folder.is_empty() {
+        return true;
+    }
+    if path == folder {
+        return true;
+    }
+
+    let prefix = normalize_folder_prefix(folder);
+    path_matches_folder_prefix(path, Some(prefix.as_str()), true)
 }
 
 #[cfg(test)]
@@ -272,6 +452,107 @@ mod tests {
             .reindex_files(dir.path(), &["note.md".to_string()])
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn reindex_files_supports_directory_targets() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("journal/sub")).unwrap();
+        fs::write(
+            dir.path().join("journal/day1.md"),
+            "# Day 1\n\nLorem ipsum dolor sit amet.",
+        )
+        .unwrap();
+        fs::write(
+            dir.path().join("journal/sub/day2.md"),
+            "# Day 2\n\nConsectetur adipiscing elit.",
+        )
+        .unwrap();
+        fs::write(dir.path().join("journal/skip.txt"), "skip").unwrap();
+
+        let (indexer, _, doc_store) = make_indexer();
+        indexer
+            .reindex_files(dir.path(), &["journal".to_string()])
+            .await
+            .unwrap();
+
+        let mut paths: Vec<String> = doc_store
+            .documents
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|d| d.source_file.clone())
+            .collect();
+        paths.sort();
+
+        assert_eq!(
+            paths,
+            vec![
+                "journal/day1.md".to_string(),
+                "journal/sub/day2.md".to_string()
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn reindex_directory_removes_stale_documents() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("journal")).unwrap();
+        fs::write(
+            dir.path().join("journal/keep.md"),
+            "# Keep\n\nLorem ipsum dolor sit amet.",
+        )
+        .unwrap();
+
+        let (indexer, store, doc_store) = make_indexer();
+        doc_store.documents.lock().unwrap().push(Document {
+            source_file: "journal/deleted.md".to_string(),
+            full_text: "deleted".to_string(),
+            title: "deleted".to_string(),
+            tags: Vec::new(),
+            content_hash: "deleted".to_string(),
+            last_modified: 0.0,
+            outgoing_links: Vec::new(),
+            backlinks: Vec::new(),
+        });
+        store.stored.lock().unwrap().push(StoredChunk {
+            note_path: "journal/deleted.md".to_string(),
+            breadcrumb: "deleted".to_string(),
+            content: "deleted".to_string(),
+            raw_content: "deleted".to_string(),
+            vector: vec![0.0; 4],
+            chunk_index: 0,
+            content_hash: "deleted".to_string(),
+            links: Vec::new(),
+        });
+
+        indexer
+            .reindex_files(dir.path(), &["journal".to_string()])
+            .await
+            .unwrap();
+
+        let docs = doc_store.documents.lock().unwrap();
+        assert!(docs.iter().all(|d| d.source_file != "journal/deleted.md"));
+        assert!(docs.iter().any(|d| d.source_file == "journal/keep.md"));
+
+        let chunks = store.stored.lock().unwrap();
+        assert!(chunks.iter().all(|c| c.note_path != "journal/deleted.md"));
+    }
+
+    #[tokio::test]
+    async fn reindex_files_rejects_parent_directory_traversal() {
+        let dir = tempfile::tempdir().unwrap();
+        let (indexer, _, _) = make_indexer();
+
+        let err = indexer
+            .reindex_files(dir.path(), &["../outside.md".to_string()])
+            .await
+            .unwrap_err();
+
+        assert!(
+            err.to_string()
+                .contains("cannot contain parent directory traversal")
+        );
     }
 
     #[tokio::test]

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -22,3 +22,6 @@ tracing = "0.1"
 tokio = { version = "1", features = ["test-util", "macros"] }
 insta = "1"
 proptest = "1"
+
+[package.metadata.cargo-machete]
+ignored = ["serde_json"]

--- a/crates/mcp/README.md
+++ b/crates/mcp/README.md
@@ -16,19 +16,19 @@ Search the vault using hybrid search (vector + full-text).
 
 ### `reindex`
 
-Reindex the vault. Without arguments performs a full reindex; with `path` reindexes a single file.
+Reindex the vault. Without arguments performs a full reindex; with `path` reindexes a single file or all files under a folder path.
 
 | Parameter | Type | Description |
 |---|---|---|
-| `path` | `Option<String>` | Relative path of a specific file (omit for full reindex) |
+| `path` | `Option<String>` | Relative path of a specific file or folder (omit for full reindex) |
 
 ### `examine`
 
-Inspect an indexed document: metadata (title, tags, outgoing links, backlinks) and content. Supports fuzzy path matching.
+Inspect one or more indexed documents: metadata (title, tags, outgoing links, backlinks) and content. Supports fuzzy path matching.
 
 | Parameter | Type | Description |
 |---|---|---|
-| `path` | `String` | Full or partial file path (fuzzy matched) |
+| `paths` | `Vec<String>` | One or more full/partial file paths (fuzzy matched) |
 | `content` | `Option<String>` | `"summary"` (default, first 500 chars), `"full"`, or `"slice"` |
 | `offset` | `Option<usize>` | Character offset for slice mode |
 | `length` | `Option<usize>` | Character count for slice mode |

--- a/crates/mcp/src/domain/documents_input.rs
+++ b/crates/mcp/src/domain/documents_input.rs
@@ -1,4 +1,5 @@
 use crate::schema::ExamineRequest;
+use anyhow::ensure;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum ExamineContentMode {
@@ -19,19 +20,33 @@ impl ExamineContentMode {
 
 #[derive(Debug, Clone)]
 pub(crate) struct ExamineInput {
-    pub path: String,
+    pub paths: Vec<String>,
     pub content_mode: ExamineContentMode,
     pub offset: usize,
     pub length: usize,
 }
 
-pub(crate) fn prepare_examine_input(req: ExamineRequest) -> ExamineInput {
-    ExamineInput {
-        path: req.path,
+pub(crate) fn prepare_examine_input(req: ExamineRequest) -> anyhow::Result<ExamineInput> {
+    ensure!(
+        !req.paths.is_empty(),
+        "At least one path is required in 'paths'"
+    );
+    let mut paths = Vec::with_capacity(req.paths.len());
+    for path in req.paths {
+        let trimmed = path.trim();
+        ensure!(
+            !trimmed.is_empty(),
+            "Paths cannot contain empty values in 'paths'"
+        );
+        paths.push(trimmed.to_string());
+    }
+
+    Ok(ExamineInput {
+        paths,
         content_mode: ExamineContentMode::from_request(req.content.as_deref()),
         offset: req.offset.unwrap_or(0),
         length: req.length.unwrap_or(500),
-    }
+    })
 }
 
 #[cfg(test)]
@@ -41,11 +56,12 @@ mod tests {
     #[test]
     fn defaults_to_summary_mode_and_default_slice_params() {
         let input = prepare_examine_input(ExamineRequest {
-            path: "a.md".to_string(),
+            paths: vec!["a.md".to_string()],
             content: None,
             offset: None,
             length: None,
-        });
+        })
+        .expect("valid request");
 
         assert_eq!(input.content_mode, ExamineContentMode::Summary);
         assert_eq!(input.offset, 0);
@@ -55,17 +71,19 @@ mod tests {
     #[test]
     fn parses_full_and_slice_modes() {
         let full = prepare_examine_input(ExamineRequest {
-            path: "a.md".to_string(),
+            paths: vec!["a.md".to_string()],
             content: Some("full".to_string()),
             offset: None,
             length: None,
-        });
+        })
+        .expect("valid request");
         let slice = prepare_examine_input(ExamineRequest {
-            path: "a.md".to_string(),
+            paths: vec!["a.md".to_string()],
             content: Some("slice".to_string()),
             offset: Some(7),
             length: Some(22),
-        });
+        })
+        .expect("valid request");
 
         assert_eq!(full.content_mode, ExamineContentMode::Full);
         assert_eq!(slice.content_mode, ExamineContentMode::Slice);
@@ -76,12 +94,26 @@ mod tests {
     #[test]
     fn unknown_mode_falls_back_to_summary_for_forward_compatibility() {
         let input = prepare_examine_input(ExamineRequest {
-            path: "a.md".to_string(),
+            paths: vec!["a.md".to_string()],
             content: Some("custom".to_string()),
             offset: None,
             length: None,
-        });
+        })
+        .expect("valid request");
 
         assert_eq!(input.content_mode, ExamineContentMode::Summary);
+    }
+
+    #[test]
+    fn empty_paths_are_rejected() {
+        let err = prepare_examine_input(ExamineRequest {
+            paths: vec![],
+            content: None,
+            offset: None,
+            length: None,
+        })
+        .unwrap_err();
+
+        assert!(err.to_string().contains("At least one path"));
     }
 }

--- a/crates/mcp/src/format/examine.rs
+++ b/crates/mcp/src/format/examine.rs
@@ -2,6 +2,17 @@ use crate::domain::documents_input::ExamineContentMode;
 use kajet_core::text_utils::{slice_by_char_boundary, truncate_with_ellipsis};
 use kajet_core::types::Document;
 
+pub(crate) enum ExamineBatchSection {
+    Success {
+        requested_path: String,
+        body: String,
+    },
+    Error {
+        requested_path: String,
+        error: String,
+    },
+}
+
 fn format_link_section(title: String, links: &[String], no_links: &str) -> String {
     if links.is_empty() {
         format!("{}\n  {}", title, no_links)
@@ -65,4 +76,61 @@ pub(crate) fn format_examine_result(
     parts.push(text_slice);
 
     parts.join("\n")
+}
+
+pub(crate) fn format_examine_batch(sections: &[ExamineBatchSection]) -> String {
+    let mut parts = vec![t!("examine_batch_header", count = sections.len()).to_string()];
+
+    for section in sections {
+        parts.push(String::new());
+        match section {
+            ExamineBatchSection::Success {
+                requested_path,
+                body,
+            } => {
+                parts.push(
+                    t!("examine_batch_separator", path = requested_path.as_str()).to_string(),
+                );
+                parts.push(body.clone());
+            }
+            ExamineBatchSection::Error {
+                requested_path,
+                error,
+            } => {
+                parts.push(
+                    t!("examine_batch_separator", path = requested_path.as_str()).to_string(),
+                );
+                parts.push(t!("examine_batch_error", error = error.as_str()).to_string());
+            }
+        }
+    }
+
+    parts.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn batch_formatter_includes_sections_and_errors() {
+        rust_i18n::set_locale("en");
+
+        let text = format_examine_batch(&[
+            ExamineBatchSection::Success {
+                requested_path: "a.md".to_string(),
+                body: "Title: A".to_string(),
+            },
+            ExamineBatchSection::Error {
+                requested_path: "missing.md".to_string(),
+                error: "Document not found".to_string(),
+            },
+        ]);
+
+        assert!(text.contains("Examined 2 documents"));
+        assert!(text.contains("=== a.md ==="));
+        assert!(text.contains("Title: A"));
+        assert!(text.contains("=== missing.md ==="));
+        assert!(text.contains("ERROR: Document not found"));
+    }
 }

--- a/crates/mcp/src/format/mod.rs
+++ b/crates/mcp/src/format/mod.rs
@@ -12,7 +12,7 @@ pub use search::format_results;
 pub use tree::{format_tree_too_large, format_vault_tree};
 
 pub(crate) use analytics::{RecentContextEntryView, RecentContextView, format_recent_context};
-pub(crate) use examine::format_examine_result;
+pub(crate) use examine::{ExamineBatchSection, format_examine_batch, format_examine_result};
 pub(crate) use tags::format_list_tags;
 
 #[cfg(test)]

--- a/crates/mcp/src/handlers/documents.rs
+++ b/crates/mcp/src/handlers/documents.rs
@@ -8,20 +8,20 @@ use tracing::instrument;
 #[tool_router(router = tool_router_documents, vis = "pub(crate)")]
 impl crate::KajetMcp {
     #[tool(
-        description = "Examine an indexed document: view its metadata (title, tags, outgoing links, backlinks) and content. Accepts full or partial file paths with fuzzy matching."
+        description = "Examine indexed documents: view metadata (title, tags, outgoing links, backlinks) and content. Accepts one or more full/partial file paths with fuzzy matching."
     )]
-    #[instrument(level = "debug", skip(self, params), fields(path))]
+    #[instrument(level = "debug", skip(self, params), fields(path_count))]
     async fn examine(
         &self,
         params: Parameters<ExamineRequest>,
     ) -> Result<CallToolResult, ErrorData> {
-        let input = prepare_examine_input(params.0);
+        let input = prepare_examine_input(params.0).map_err(|e| internal_error(e.to_string()))?;
         let span = tracing::Span::current();
-        span.record("path", input.path.as_str());
+        span.record("path_count", input.paths.len());
 
         let out = execute_examine(
             self,
-            &input.path,
+            &input.paths,
             input.content_mode,
             input.offset,
             input.length,

--- a/crates/mcp/src/handlers/index.rs
+++ b/crates/mcp/src/handlers/index.rs
@@ -6,7 +6,7 @@ use rmcp::{handler::server::wrapper::Parameters, model::*, tool, tool_router};
 #[tool_router(router = tool_router_index, vis = "pub(crate)")]
 impl crate::KajetMcp {
     #[tool(
-        description = "Reindex the Obsidian vault. Without arguments, performs a full vault reindex. With a 'path' argument, reindexes only that specific file."
+        description = "Reindex the Obsidian vault. Without arguments, performs a full vault reindex. With a 'path' argument, reindexes that specific file or all files under that folder."
     )]
     async fn reindex(
         &self,
@@ -19,7 +19,7 @@ impl crate::KajetMcp {
 
         match output {
             ReindexOutput::SingleFile { summary, path } => {
-                tracing::info!(path = %path, "MCP reindex file");
+                tracing::info!(path = %path, "MCP reindex path");
                 Ok(CallToolResult::success(vec![Content::text(summary)]))
             }
             ReindexOutput::Full { summary } => {

--- a/crates/mcp/src/ports.rs
+++ b/crates/mcp/src/ports.rs
@@ -1,6 +1,6 @@
 use crate::domain::search_input::SearchMode;
 use kajet_core::actions::{ActionEvent, SearchResultSummary};
-use kajet_core::search::{ExamineResult, SearchResult};
+use kajet_core::search::{ExamineManyResult, SearchResult};
 use kajet_core::types::{Document, IndexStats};
 use std::path::{Path, PathBuf};
 
@@ -247,12 +247,12 @@ impl IndexPorts for crate::KajetMcp {
 }
 
 pub(crate) trait DocumentsPorts {
-    async fn examine(&self, path: &str) -> anyhow::Result<ExamineResult>;
+    async fn examine_many(&self, paths: &[String]) -> anyhow::Result<Vec<ExamineManyResult>>;
 }
 
 impl DocumentsPorts for crate::KajetMcp {
-    async fn examine(&self, path: &str) -> anyhow::Result<ExamineResult> {
-        self.state.search_engine.examine(path).await
+    async fn examine_many(&self, paths: &[String]) -> anyhow::Result<Vec<ExamineManyResult>> {
+        self.state.search_engine.examine_many(paths).await
     }
 }
 

--- a/crates/mcp/src/schema.rs
+++ b/crates/mcp/src/schema.rs
@@ -2,20 +2,20 @@ use rmcp::schemars;
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct ReindexRequest {
-    /// Optional relative path of a specific file to reindex. If omitted, full vault reindex.
+    /// Optional relative path of a specific file or folder to reindex. If omitted, full vault reindex.
     #[schemars(
-        description = "Optional relative path of a specific file to reindex. Omit for full vault reindex."
+        description = "Optional relative path of a specific file or folder to reindex. Omit for full vault reindex."
     )]
     pub path: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct ExamineRequest {
-    /// Path to the document (full or partial, e.g. "myfile.md" or "subfolder/myfile")
+    /// One or more document paths (full or partial, e.g. "myfile.md" or "subfolder/myfile")
     #[schemars(
-        description = "Path to the document — full relative path or partial (filename). Fuzzy suffix matching is used if exact match fails."
+        description = "One or more document paths — full relative path or partial (filename). Fuzzy suffix matching is used if exact match fails."
     )]
-    pub path: String,
+    pub paths: Vec<String>,
 
     /// Content display mode: "summary" (first 500 chars, default), "full" (entire content), "slice" (use offset+length)
     #[schemars(

--- a/crates/mcp/src/use_cases/documents.rs
+++ b/crates/mcp/src/use_cases/documents.rs
@@ -1,6 +1,7 @@
 use crate::domain::documents_input::ExamineContentMode;
-use crate::format::format_examine_result;
+use crate::format::{ExamineBatchSection, format_examine_batch, format_examine_result};
 use crate::ports::DocumentsPorts;
+use kajet_core::search::ExamineManyResult;
 
 pub(crate) struct ExamineOutput {
     pub summary: String,
@@ -8,32 +9,69 @@ pub(crate) struct ExamineOutput {
 
 pub(crate) async fn execute_examine(
     ports: &impl DocumentsPorts,
-    path: &str,
+    paths: &[String],
     content_mode: ExamineContentMode,
     offset: usize,
     length: usize,
 ) -> anyhow::Result<ExamineOutput> {
-    let result = ports.examine(path).await?;
-    let text = format_examine_result(&result.document, content_mode, offset, length);
-    Ok(ExamineOutput { summary: text })
+    let mut sections = Vec::with_capacity(paths.len());
+    for item in ports.examine_many(paths).await? {
+        match item {
+            ExamineManyResult::Success {
+                requested_path,
+                document,
+            } => {
+                let text = format_examine_result(&document, content_mode, offset, length);
+                sections.push(ExamineBatchSection::Success {
+                    requested_path,
+                    body: text,
+                });
+            }
+            ExamineManyResult::Error {
+                requested_path,
+                error,
+            } => {
+                sections.push(ExamineBatchSection::Error {
+                    requested_path,
+                    error,
+                });
+            }
+        }
+    }
+
+    Ok(ExamineOutput {
+        summary: format_examine_batch(&sections),
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kajet_core::search::ExamineResult;
+    use kajet_core::search::ExamineManyResult;
     use kajet_core::types::Document;
+    use std::collections::HashMap;
 
     #[derive(Clone)]
     struct FakeDocumentsPorts {
-        doc: Document,
+        docs: HashMap<String, Document>,
     }
 
     impl DocumentsPorts for FakeDocumentsPorts {
-        async fn examine(&self, _path: &str) -> anyhow::Result<ExamineResult> {
-            Ok(ExamineResult {
-                document: self.doc.clone(),
-            })
+        async fn examine_many(&self, paths: &[String]) -> anyhow::Result<Vec<ExamineManyResult>> {
+            let mut out = Vec::with_capacity(paths.len());
+            for path in paths {
+                match self.docs.get(path) {
+                    Some(doc) => out.push(ExamineManyResult::Success {
+                        requested_path: path.clone(),
+                        document: doc.clone(),
+                    }),
+                    None => out.push(ExamineManyResult::Error {
+                        requested_path: path.clone(),
+                        error: format!("Document not found: {path}"),
+                    }),
+                }
+            }
+            Ok(out)
         }
     }
 
@@ -52,11 +90,21 @@ mod tests {
 
     #[tokio::test]
     async fn execute_examine_formats_summary_mode() {
-        let ports = FakeDocumentsPorts { doc: sample_doc() };
-        let out = execute_examine(&ports, "demo", ExamineContentMode::Summary, 0, 500)
-            .await
-            .expect("ok");
+        let ports = FakeDocumentsPorts {
+            docs: HashMap::from([(String::from("demo"), sample_doc())]),
+        };
+        let out = execute_examine(
+            &ports,
+            &[String::from("demo")],
+            ExamineContentMode::Summary,
+            0,
+            500,
+        )
+        .await
+        .expect("ok");
 
+        assert!(out.summary.contains("Examined 1 documents"));
+        assert!(out.summary.contains("=== demo ==="));
         assert!(out.summary.contains("Demo"));
         assert!(out.summary.contains("rust"));
         assert!(out.summary.contains("Hello world from kajet"));
@@ -64,11 +112,41 @@ mod tests {
 
     #[tokio::test]
     async fn execute_examine_formats_slice_mode() {
-        let ports = FakeDocumentsPorts { doc: sample_doc() };
-        let out = execute_examine(&ports, "demo", ExamineContentMode::Slice, 6, 5)
-            .await
-            .expect("ok");
+        let ports = FakeDocumentsPorts {
+            docs: HashMap::from([(String::from("demo"), sample_doc())]),
+        };
+        let out = execute_examine(
+            &ports,
+            &[String::from("demo")],
+            ExamineContentMode::Slice,
+            6,
+            5,
+        )
+        .await
+        .expect("ok");
 
         assert!(out.summary.contains("world"));
+    }
+
+    #[tokio::test]
+    async fn execute_examine_partial_success_includes_error_section() {
+        let ports = FakeDocumentsPorts {
+            docs: HashMap::from([(String::from("demo"), sample_doc())]),
+        };
+        let out = execute_examine(
+            &ports,
+            &[String::from("demo"), String::from("missing.md")],
+            ExamineContentMode::Summary,
+            0,
+            500,
+        )
+        .await
+        .expect("ok");
+
+        assert!(out.summary.contains("Examined 2 documents"));
+        assert!(out.summary.contains("=== demo ==="));
+        assert!(out.summary.contains("=== missing.md ==="));
+        assert!(out.summary.contains("ERROR:"));
+        assert!(out.summary.contains("Document not found: missing.md"));
     }
 }

--- a/frontend/src/lib/components/Logs.svelte
+++ b/frontend/src/lib/components/Logs.svelte
@@ -114,22 +114,27 @@
             {@const data = entry.data}
             {@const expandable = hasFields(entry)}
             <div class="log-item">
-              <div
-                class="log-entry"
-                class:expandable
-                class:expanded={expandedIndex === index}
-                onclick={() => expandable && toggleExpand(index)}
-                role={expandable ? 'button' : undefined}
-                tabindex={expandable ? 0 : undefined}
-              >
-                <span class="time">{formatTime(data.timestamp)}</span>
-                <span class="level" style:color={levelColor(data.level)}>{data.level.padEnd(5)}</span>
-                <span class="target">{data.target}</span>
-                <span class="message">{data.message}</span>
-                {#if expandable}
+              {#if expandable}
+                <button
+                  type="button"
+                  class="log-entry log-entry-button expandable"
+                  class:expanded={expandedIndex === index}
+                  onclick={() => toggleExpand(index)}
+                >
+                  <span class="time">{formatTime(data.timestamp)}</span>
+                  <span class="level" style:color={levelColor(data.level)}>{data.level.padEnd(5)}</span>
+                  <span class="target">{data.target}</span>
+                  <span class="message">{data.message}</span>
                   <span class="expand-icon">{expandedIndex === index ? '▼' : '▶'}</span>
-                {/if}
-              </div>
+                </button>
+              {:else}
+                <div class="log-entry">
+                  <span class="time">{formatTime(data.timestamp)}</span>
+                  <span class="level" style:color={levelColor(data.level)}>{data.level.padEnd(5)}</span>
+                  <span class="target">{data.target}</span>
+                  <span class="message">{data.message}</span>
+                </div>
+              {/if}
               {#if expandable && expandedIndex === index && data.fields}
                 <div class="fields-panel">
                   {#each Object.entries(data.fields) as [key, value]}
@@ -243,6 +248,14 @@
     padding: 0.25rem 0.3rem;
     border-bottom: 1px solid #1a1a1a;
     white-space: nowrap;
+  }
+  .log-entry-button {
+    width: 100%;
+    background: transparent;
+    border: none;
+    color: inherit;
+    font: inherit;
+    text-align: left;
   }
   .log-entry.expandable {
     cursor: pointer;

--- a/frontend/src/lib/components/Settings.svelte
+++ b/frontend/src/lib/components/Settings.svelte
@@ -321,7 +321,7 @@
         <DynamicSettings
           {schema}
           config={vaultConfig}
-          globalConfig={config}
+          globalConfig={globalConfig}
           scope="Vault"
           onsave={saveVault}
           onreset={handleFieldReset}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,3 +9,21 @@ pre-commit:
       run: typos
       skip:
         - run: "! which typos >/dev/null 2>&1"
+
+pre-push:
+  parallel: false
+  commands:
+    10-rust-generate-frontend-types:
+      run: cargo test -p kajet-core -p kajet-parser --lib --no-fail-fast
+    20-frontend-typecheck:
+      run: cd frontend && deno task check
+      skip:
+        - run: "! which deno >/dev/null 2>&1"
+    30-frontend-build:
+      run: cd frontend && deno task build
+      skip:
+        - run: "! which deno >/dev/null 2>&1"
+    40-unused-deps:
+      run: cargo machete
+      skip:
+        - run: "! which cargo-machete >/dev/null 2>&1"

--- a/locales/en.toml
+++ b/locales/en.toml
@@ -91,7 +91,7 @@ query_duration = "Duration"
 # MCP — reindex/status tools
 reindex_started = "Full vault reindex started."
 reindex_complete = "Reindex complete: %{documents} documents, %{chunks} chunks."
-reindex_file_complete = "Reindexed file: %{path}"
+reindex_file_complete = "Reindexed path: %{path}"
 reindex_failed = "Reindex failed: %{error}"
 index_status_header = "Index Status"
 index_status_documents = "Documents: %{count}"
@@ -109,6 +109,9 @@ examine_outgoing_links = "Outgoing links (%{count}):"
 examine_backlinks = "Backlinks (%{count}):"
 examine_no_links = "none"
 examine_content_info = "Content: %{shown}/%{total} chars"
+examine_batch_header = "Examined %{count} documents:"
+examine_batch_separator = "=== %{path} ==="
+examine_batch_error = "ERROR: %{error}"
 
 # MCP — create_note / edit_note tools
 create_note_success = "Created note: %{path} (%{bytes} bytes)"

--- a/locales/pl.toml
+++ b/locales/pl.toml
@@ -91,7 +91,7 @@ query_duration = "Czas"
 # MCP — narzędzia reindex/status
 reindex_started = "Rozpoczęto pełne reindeksowanie vault."
 reindex_complete = "Reindeksowanie zakończone: %{documents} dokumentów, %{chunks} fragmentów."
-reindex_file_complete = "Przeindeksowano plik: %{path}"
+reindex_file_complete = "Przeindeksowano ścieżkę: %{path}"
 reindex_failed = "Reindeksowanie nie powiodło się: %{error}"
 index_status_header = "Status indeksu"
 index_status_documents = "Dokumenty: %{count}"
@@ -109,6 +109,9 @@ examine_outgoing_links = "Linki wychodzące (%{count}):"
 examine_backlinks = "Backlinki (%{count}):"
 examine_no_links = "brak"
 examine_content_info = "Treść: %{shown}/%{total} znaków"
+examine_batch_header = "Przeanalizowano %{count} dokumentów:"
+examine_batch_separator = "=== %{path} ==="
+examine_batch_error = "BŁĄD: %{error}"
 
 # MCP — narzędzia create_note / edit_note
 create_note_success = "Utworzono notatkę: %{path} (%{bytes} bajtów)"


### PR DESCRIPTION
## Summary
- add batch examine support for multiple paths in a single request
- add path handling updates related to folder reindex/multi-path flows
- include follow-up fixes to keep frontend checks and pre-push quality gates green

## Validation
- cargo test -p kajet-core -p kajet-parser --lib --no-fail-fast
- deno task check
- deno task build
- cargo machete

Closes #73