### PR TITLE
refactor: unify fuzzy path matching for examine and writer

### DIFF
--- a/crates/core/src/path_utils.rs
+++ b/crates/core/src/path_utils.rs
@@ -33,3 +33,93 @@ pub fn path_matches_folder_prefix(
 
     true
 }
+
+/// Normalize note lookup input by converting Windows separators to `/`.
+pub fn normalize_note_lookup_path(path: &str) -> String {
+    path.replace('\\', "/")
+}
+
+/// Fuzzy-match a candidate note path against query path.
+///
+/// Matching rules:
+/// - exact path (`journal/today.md`)
+/// - exact with implicit `.md` (`journal/today`)
+/// - suffix match (`today` -> `journal/today.md`)
+pub fn note_path_fuzzy_matches(
+    candidate_path: &str,
+    query_path: &str,
+    case_insensitive: bool,
+) -> bool {
+    let normalized_query = normalize_note_lookup_path(query_path);
+    let query = if case_insensitive {
+        normalized_query.to_lowercase()
+    } else {
+        normalized_query
+    };
+    let candidate = if case_insensitive {
+        candidate_path.to_lowercase()
+    } else {
+        candidate_path.to_string()
+    };
+
+    let suffix = format!("/{query}");
+    let suffix_md = format!("/{query}.md");
+    let query_md = format!("{query}.md");
+
+    candidate == query
+        || candidate == query_md
+        || candidate.ends_with(&suffix)
+        || candidate.ends_with(&suffix_md)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn note_path_fuzzy_matches_exact_and_suffix() {
+        assert!(note_path_fuzzy_matches(
+            "journal/2026/today.md",
+            "journal/2026/today.md",
+            false
+        ));
+        assert!(note_path_fuzzy_matches(
+            "journal/2026/today.md",
+            "journal/2026/today",
+            false
+        ));
+        assert!(note_path_fuzzy_matches(
+            "journal/2026/today.md",
+            "today",
+            false
+        ));
+        assert!(note_path_fuzzy_matches(
+            "journal/2026/today.md",
+            "today.md",
+            false
+        ));
+    }
+
+    #[test]
+    fn note_path_fuzzy_matches_normalizes_windows_separators() {
+        assert!(note_path_fuzzy_matches(
+            "journal/2026/today.md",
+            "journal\\2026\\today",
+            false
+        ));
+    }
+
+    #[test]
+    fn note_path_fuzzy_matches_case_insensitive_mode() {
+        assert!(note_path_fuzzy_matches(
+            "Journal/Today.MD",
+            "journal/today",
+            true
+        ));
+        assert!(!note_path_fuzzy_matches(
+            "Journal/Today.MD",
+            "journal/today",
+            false
+        ));
+    }
+}

--- a/crates/core/src/search.rs
+++ b/crates/core/src/search.rs
@@ -1,4 +1,5 @@
 use crate::embedding_input::apply_prefix;
+use crate::path_utils::note_path_fuzzy_matches;
 use crate::traits::{DocumentStore, Embedder, VectorStore};
 use crate::types::{Document, SearchType};
 use anyhow::Result;
@@ -226,18 +227,9 @@ impl SearchEngine {
 }
 
 fn fuzzy_match_examine_document<'a>(all_docs: &'a [Document], path: &str) -> Result<&'a Document> {
-    let suffix = format!("/{path}");
-    let suffix_md = format!("/{path}.md");
-    let path_md = format!("{path}.md");
-
     let matches: Vec<&Document> = all_docs
         .iter()
-        .filter(|d| {
-            d.source_file.ends_with(&suffix)
-                || d.source_file == path
-                || d.source_file.ends_with(&suffix_md)
-                || d.source_file == path_md
-        })
+        .filter(|d| note_path_fuzzy_matches(&d.source_file, path, true))
         .collect();
 
     match matches.len() {
@@ -573,6 +565,37 @@ mod tests {
                 assert!(error.contains("Multiple matches"));
             }
             ExamineManyResult::Success { .. } => panic!("expected ambiguous error"),
+        }
+    }
+
+    #[tokio::test]
+    async fn examine_many_matches_case_insensitive_query() {
+        let engine = make_search_engine_with_docs(vec![sample_doc("journal/demo.md", "Demo")]);
+        let results = engine.examine_many(&["DEMO".to_string()]).await.unwrap();
+
+        assert_eq!(results.len(), 1);
+        match &results[0] {
+            ExamineManyResult::Success { document, .. } => {
+                assert_eq!(document.source_file, "journal/demo.md");
+            }
+            ExamineManyResult::Error { .. } => panic!("expected success"),
+        }
+    }
+
+    #[tokio::test]
+    async fn examine_many_matches_windows_style_path() {
+        let engine = make_search_engine_with_docs(vec![sample_doc("journal/2026/demo.md", "Demo")]);
+        let results = engine
+            .examine_many(&["journal\\2026\\demo".to_string()])
+            .await
+            .unwrap();
+
+        assert_eq!(results.len(), 1);
+        match &results[0] {
+            ExamineManyResult::Success { document, .. } => {
+                assert_eq!(document.source_file, "journal/2026/demo.md");
+            }
+            ExamineManyResult::Error { .. } => panic!("expected success"),
         }
     }
 

--- a/crates/writer/src/resolve.rs
+++ b/crates/writer/src/resolve.rs
@@ -1,4 +1,5 @@
 use anyhow::{Result, bail};
+use kajet_core::path_utils::{normalize_note_lookup_path, note_path_fuzzy_matches};
 use kajet_core::traits::DocumentStore;
 use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
@@ -21,7 +22,7 @@ pub async fn resolve_note_path(
     doc_store: Option<&Arc<dyn DocumentStore>>,
 ) -> Result<ResolvedPath> {
     // Reject path traversal
-    let normalized = target.replace('\\', "/");
+    let normalized = normalize_note_lookup_path(target);
     let path = Path::new(&normalized);
     for component in path.components() {
         if matches!(component, Component::ParentDir) {
@@ -56,16 +57,9 @@ pub async fn resolve_note_path(
     if let Some(store) = doc_store
         && let Ok(docs) = store.get_all_documents().await
     {
-        let needle = normalized.to_lowercase();
         let matches: Vec<_> = docs
             .iter()
-            .filter(|d| {
-                let path = d.source_file.to_lowercase();
-                path == needle
-                    || path == format!("{needle}.md")
-                    || path.ends_with(&format!("/{needle}"))
-                    || path.ends_with(&format!("/{needle}.md"))
-            })
+            .filter(|d| note_path_fuzzy_matches(&d.source_file, &normalized, true))
             .collect();
 
         match matches.len() {
@@ -91,7 +85,9 @@ pub async fn resolve_note_path(
     }
 
     // Step 3: filesystem walk
-    if let Some(found) = walk_for_filename(vault_path, &normalized).await? {
+    if !normalized.contains('/')
+        && let Some(found) = walk_for_filename(vault_path, &normalized).await?
+    {
         return Ok(found);
     }
 
@@ -240,6 +236,39 @@ mod tests {
 
         let store: Arc<dyn DocumentStore> = Arc::new(store);
         let resolved = resolve_note_path("ideas", vault, Some(&store))
+            .await
+            .unwrap();
+        assert_eq!(resolved.relative, "projects/ideas.md");
+    }
+
+    #[tokio::test]
+    async fn resolve_via_docstore_case_insensitive_with_windows_path() {
+        use kajet_core::traits::mocks::MockDocumentStore;
+        use kajet_core::types::Document;
+
+        let dir = tempfile::tempdir().unwrap();
+        let vault = dir.path();
+        tokio::fs::create_dir_all(vault.join("projects"))
+            .await
+            .unwrap();
+        tokio::fs::write(vault.join("projects/ideas.md"), "# Ideas")
+            .await
+            .unwrap();
+
+        let store = MockDocumentStore::new();
+        store.documents.lock().unwrap().push(Document {
+            source_file: "projects/ideas.md".into(),
+            full_text: "# Ideas".into(),
+            title: "Ideas".into(),
+            tags: vec![],
+            content_hash: "abc".into(),
+            last_modified: 0.0,
+            outgoing_links: vec![],
+            backlinks: vec![],
+        });
+
+        let store: Arc<dyn DocumentStore> = Arc::new(store);
+        let resolved = resolve_note_path("IDEAS", vault, Some(&store))
             .await
             .unwrap();
         assert_eq!(resolved.relative, "projects/ideas.md");


### PR DESCRIPTION
## Summary
- extract shared note-path fuzzy matcher into `kajet_core::path_utils`
- switch `SearchEngine::examine` and `examine_many` to shared matcher
- switch writer resolver fuzzy step to shared matcher
- keep writer filesystem fallback, but constrain it to bare filename lookups (no `/`), reducing broad scans

## Why
- remove duplicated matching logic between core examine path resolution and writer path resolution
- ensure consistent behavior for case-insensitive and Windows-style path inputs
- improve maintainability and reduce drift risk between read/write paths

## Validation
- `cargo test -p kajet-core --lib`
- `cargo test -p kajet-writer --lib`
- `cargo machete`
- pre-push hook passed (`rust-generate-frontend-types`, `frontend-typecheck`, `frontend-build`, `unused-deps`)
