### PR TITLE
feat(mcp): add explore_connections graph traversal tool

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -95,6 +95,34 @@ impl Default for TreeConfig {
     }
 }
 
+#[derive(Debug, Clone, Deserialize, serde::Serialize)]
+#[serde(default)]
+pub struct ExploreConnectionsConfig {
+    pub default_depth: usize,
+    pub default_limit: usize,
+    pub default_dedup: bool,
+    pub default_include_context: bool,
+    pub default_filter_mode: String,
+}
+
+impl Default for ExploreConnectionsConfig {
+    fn default() -> Self {
+        Self {
+            default_depth: 3,
+            default_limit: 100,
+            default_dedup: true,
+            default_include_context: false,
+            default_filter_mode: "display".into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Deserialize, serde::Serialize)]
+#[serde(default)]
+pub struct McpConfig {
+    pub explore_connections: ExploreConnectionsConfig,
+}
+
 #[derive(Debug, Clone, Deserialize, serde::Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum EmbeddingBackend {
@@ -147,6 +175,7 @@ pub struct KajetConfig {
     pub logging: LoggingConfig,
     pub writer: WriterConfig,
     pub tree: TreeConfig,
+    pub mcp: McpConfig,
 }
 
 impl Default for KajetConfig {
@@ -166,6 +195,7 @@ impl Default for KajetConfig {
             logging: LoggingConfig::default(),
             writer: WriterConfig::default(),
             tree: TreeConfig::default(),
+            mcp: McpConfig::default(),
         }
     }
 }
@@ -186,10 +216,11 @@ const GLOBAL_FIELDS: &[&str] = &[
     "logging",
     "writer",
     "tree",
+    "mcp",
 ];
 
 /// Fields allowed in vault-level config.
-const VAULT_FIELDS: &[&str] = &["exclude_folders", "embedding", "writer", "tree"];
+const VAULT_FIELDS: &[&str] = &["exclude_folders", "embedding", "writer", "tree", "mcp"];
 
 /// Load config with layered priority: defaults < global < per-vault < env < CLI.
 ///
@@ -240,7 +271,12 @@ pub fn load_config(
         .set_default::<&str, Option<String>>("writer.frontmatter.date_field", None)?
         .set_default("tree.depth", 3_i64)?
         .set_default("tree.size", 50_i64)?
-        .set_default("tree.max_chars", 5000_i64)?;
+        .set_default("tree.max_chars", 5000_i64)?
+        .set_default("mcp.explore_connections.default_depth", 3_i64)?
+        .set_default("mcp.explore_connections.default_limit", 100_i64)?
+        .set_default("mcp.explore_connections.default_dedup", true)?
+        .set_default("mcp.explore_connections.default_include_context", false)?
+        .set_default("mcp.explore_connections.default_filter_mode", "display")?;
 
     // 2. Global config: ~/.config/kajet/config.toml
     if let Some(config_dir) = dirs::config_dir() {
@@ -683,6 +719,36 @@ model = "new-model"
         assert_eq!(tree["depth"].as_integer(), Some(5));
         assert_eq!(tree["size"].as_integer(), Some(100));
         assert_eq!(tree["max_chars"].as_integer(), Some(10000));
+    }
+
+    #[test]
+    fn explore_connections_config_defaults() {
+        let config = KajetConfig::default();
+        assert_eq!(config.mcp.explore_connections.default_depth, 3);
+        assert_eq!(config.mcp.explore_connections.default_limit, 100);
+        assert!(config.mcp.explore_connections.default_dedup);
+        assert!(!config.mcp.explore_connections.default_include_context);
+        assert_eq!(
+            config.mcp.explore_connections.default_filter_mode,
+            "display"
+        );
+    }
+
+    #[test]
+    fn explore_connections_config_allowed_in_global_and_vault() {
+        let mut updates = HashMap::new();
+        let mut explore_table = toml::Table::new();
+        explore_table.insert("default_depth".into(), toml::Value::Integer(5));
+
+        let mut mcp_table = toml::Table::new();
+        mcp_table.insert(
+            "explore_connections".into(),
+            toml::Value::Table(explore_table),
+        );
+        updates.insert("mcp".into(), toml::Value::Table(mcp_table));
+
+        assert!(validate_fields(&updates, GLOBAL_FIELDS, "global").is_ok());
+        assert!(validate_fields(&updates, VAULT_FIELDS, "vault").is_ok());
     }
 
     #[test]

--- a/crates/core/src/search.rs
+++ b/crates/core/src/search.rs
@@ -161,7 +161,7 @@ impl SearchEngine {
 
         // 2. Fuzzy: suffix match on all documents
         let all_docs = self.doc_store.get_all_documents().await?;
-        let doc = fuzzy_match_examine_document(&all_docs, path)?;
+        let doc = resolve_examine_document(&all_docs, path)?;
         Ok(ExamineResult {
             document: doc.clone(),
         })
@@ -186,7 +186,7 @@ impl SearchEngine {
                 continue;
             }
 
-            match fuzzy_match_examine_document(&all_docs, path) {
+            match resolve_examine_document(&all_docs, path) {
                 Ok(doc) => out.push(ExamineManyResult::Success {
                     requested_path: path.clone(),
                     document: doc.clone(),
@@ -226,7 +226,7 @@ impl SearchEngine {
     }
 }
 
-fn fuzzy_match_examine_document<'a>(all_docs: &'a [Document], path: &str) -> Result<&'a Document> {
+pub fn resolve_examine_document<'a>(all_docs: &'a [Document], path: &str) -> Result<&'a Document> {
     let matches: Vec<&Document> = all_docs
         .iter()
         .filter(|d| note_path_fuzzy_matches(&d.source_file, path, true))

--- a/crates/mcp/README.md
+++ b/crates/mcp/README.md
@@ -33,6 +33,29 @@ Inspect one or more indexed documents: metadata (title, tags, outgoing links, ba
 | `offset` | `Option<usize>` | Character offset for slice mode |
 | `length` | `Option<usize>` | Character count for slice mode |
 
+### `explore_connections`
+
+Traverse note connections as a graph tree starting from one note. Supports depth/limit, dedup, optional section context, and filter modes.
+
+| Parameter | Type | Description |
+|---|---|---|
+| `path` | `String` | Starting note path (full/partial, fuzzy matched) |
+| `depth` | `Option<usize>` | Max traversal depth (default from config) |
+| `limit` | `Option<usize>` | Max nodes shown in output (default from config) |
+| `dedup` | `Option<bool>` | `true` (default) to show each node once |
+| `include_context` | `Option<bool>` | Include section names where links appear |
+| `filter_mode` | `Option<String>` | `"display"` (default) or `"traverse"` |
+| `from`/`to` | `Option<String>` | Optional date range filters |
+| `tags` | `Option<Vec<String>>` | Optional tags filter (all required) |
+| `folder` | `Option<String>` | Optional folder prefix filter |
+
+`filter_mode` behavior:
+- `display` (default): traverse full graph, but only show nodes matching filters.
+- `traverse`: only traverse through nodes matching filters (stops at non-matching nodes).
+
+Path matching note:
+- `path` uses fuzzy suffix matching against note file paths (e.g. `daily.md`, `journal/daily`), not note titles.
+
 ### `index_status`
 
 Get current index status: document count, chunk count, last indexing time. No parameters.

--- a/crates/mcp/src/domain/explore_input.rs
+++ b/crates/mcp/src/domain/explore_input.rs
@@ -1,0 +1,221 @@
+use crate::date_parser::{DateBound, parse_date};
+use crate::schema::ExploreConnectionsRequest;
+use chrono::NaiveDate;
+use kajet_core::config::ExploreConnectionsConfig;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ExploreFilterMode {
+    Display,
+    Traverse,
+}
+
+impl ExploreFilterMode {
+    pub(crate) fn from_request(mode: Option<&str>, default_mode: &str) -> Self {
+        match mode.unwrap_or(default_mode) {
+            "traverse" => Self::Traverse,
+            _ => Self::Display,
+        }
+    }
+
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Display => "display",
+            Self::Traverse => "traverse",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ExploreConnectionsInput {
+    pub path: String,
+    pub depth: usize,
+    pub limit: usize,
+    pub dedup: bool,
+    pub include_context: bool,
+    pub filter_mode: ExploreFilterMode,
+    pub from_ts: Option<f64>,
+    pub to_ts: Option<f64>,
+    pub folder: Option<String>,
+    pub tags: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum ExploreInputError {
+    EmptyPath,
+    DepthZero,
+    LimitZero,
+    DateParse { input: String, error: String },
+    InvalidDateRange { from: NaiveDate, to: NaiveDate },
+}
+
+pub(crate) fn prepare_explore_connections_input(
+    req: ExploreConnectionsRequest,
+    defaults: &ExploreConnectionsConfig,
+    today: NaiveDate,
+) -> Result<ExploreConnectionsInput, ExploreInputError> {
+    let path = req.path.trim().to_string();
+    if path.is_empty() {
+        return Err(ExploreInputError::EmptyPath);
+    }
+
+    let depth = req.depth.unwrap_or(defaults.default_depth);
+    if depth == 0 {
+        return Err(ExploreInputError::DepthZero);
+    }
+
+    let limit = req.limit.unwrap_or(defaults.default_limit);
+    if limit == 0 {
+        return Err(ExploreInputError::LimitZero);
+    }
+
+    let from_date = if let Some(ref from_str) = req.from {
+        Some(parse_date(from_str, DateBound::From).map_err(|e| {
+            let input = e.input.clone();
+            ExploreInputError::DateParse {
+                input,
+                error: e.to_string(),
+            }
+        })?)
+    } else {
+        None
+    };
+
+    let to_date = if let Some(ref to_str) = req.to {
+        Some(parse_date(to_str, DateBound::To).map_err(|e| {
+            let input = e.input.clone();
+            ExploreInputError::DateParse {
+                input,
+                error: e.to_string(),
+            }
+        })?)
+    } else if from_date.is_some() {
+        Some(today)
+    } else {
+        None
+    };
+
+    if let (Some(from), Some(to)) = (from_date, to_date)
+        && from > to
+    {
+        return Err(ExploreInputError::InvalidDateRange { from, to });
+    }
+
+    let from_ts = from_date.map(|d| {
+        d.and_hms_opt(0, 0, 0)
+            .expect("00:00:00 is always valid")
+            .and_utc()
+            .timestamp() as f64
+    });
+    let to_ts = to_date.map(|d| {
+        d.and_hms_opt(23, 59, 59)
+            .expect("23:59:59 is always valid")
+            .and_utc()
+            .timestamp() as f64
+    });
+
+    Ok(ExploreConnectionsInput {
+        path,
+        depth,
+        limit,
+        dedup: req.dedup.unwrap_or(defaults.default_dedup),
+        include_context: req
+            .include_context
+            .unwrap_or(defaults.default_include_context),
+        filter_mode: ExploreFilterMode::from_request(
+            req.filter_mode.as_deref(),
+            &defaults.default_filter_mode,
+        ),
+        from_ts,
+        to_ts,
+        folder: req.folder,
+        tags: req.tags,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn defaults() -> ExploreConnectionsConfig {
+        ExploreConnectionsConfig::default()
+    }
+
+    #[test]
+    fn applies_defaults_when_optional_fields_missing() {
+        let input = prepare_explore_connections_input(
+            ExploreConnectionsRequest {
+                path: "note.md".to_string(),
+                depth: None,
+                limit: None,
+                dedup: None,
+                include_context: None,
+                filter_mode: None,
+                tags: None,
+                from: None,
+                to: None,
+                folder: None,
+            },
+            &defaults(),
+            NaiveDate::from_ymd_opt(2026, 2, 15).expect("valid date"),
+        )
+        .expect("valid request");
+
+        assert_eq!(input.depth, 3);
+        assert_eq!(input.limit, 100);
+        assert!(input.dedup);
+        assert!(!input.include_context);
+        assert_eq!(input.filter_mode, ExploreFilterMode::Display);
+    }
+
+    #[test]
+    fn parses_traverse_mode_and_date_defaults() {
+        let input = prepare_explore_connections_input(
+            ExploreConnectionsRequest {
+                path: "note.md".to_string(),
+                depth: Some(2),
+                limit: Some(50),
+                dedup: Some(false),
+                include_context: Some(true),
+                filter_mode: Some("traverse".to_string()),
+                tags: Some(vec!["research".to_string()]),
+                from: Some("2026-02-10".to_string()),
+                to: None,
+                folder: Some("journal".to_string()),
+            },
+            &defaults(),
+            NaiveDate::from_ymd_opt(2026, 2, 15).expect("valid date"),
+        )
+        .expect("valid request");
+
+        assert_eq!(input.filter_mode, ExploreFilterMode::Traverse);
+        assert_eq!(input.depth, 2);
+        assert_eq!(input.limit, 50);
+        assert!(!input.dedup);
+        assert!(input.include_context);
+        assert!(input.from_ts.is_some());
+        assert!(input.to_ts.is_some());
+    }
+
+    #[test]
+    fn rejects_empty_path() {
+        let err = prepare_explore_connections_input(
+            ExploreConnectionsRequest {
+                path: "   ".to_string(),
+                depth: None,
+                limit: None,
+                dedup: None,
+                include_context: None,
+                filter_mode: None,
+                tags: None,
+                from: None,
+                to: None,
+                folder: None,
+            },
+            &defaults(),
+            NaiveDate::from_ymd_opt(2026, 2, 15).expect("valid date"),
+        )
+        .expect_err("must fail");
+
+        assert!(matches!(err, ExploreInputError::EmptyPath));
+    }
+}

--- a/crates/mcp/src/domain/mod.rs
+++ b/crates/mcp/src/domain/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod analytics_input;
 pub(crate) mod documents_input;
+pub(crate) mod explore_input;
 pub(crate) mod notes_input;
 pub(crate) mod search_input;
 pub(crate) mod tags_input;

--- a/crates/mcp/src/filters/documents.rs
+++ b/crates/mcp/src/filters/documents.rs
@@ -1,0 +1,86 @@
+use crate::filters::tags_match;
+use kajet_core::path_utils::{normalize_folder_prefix, path_matches_folder_prefix};
+use kajet_core::types::Document;
+
+pub(crate) struct DocumentFilters<'a> {
+    folder_prefix: Option<String>,
+    from_ts: Option<f64>,
+    to_ts: Option<f64>,
+    tags: Option<&'a [String]>,
+}
+
+impl<'a> DocumentFilters<'a> {
+    pub(crate) fn new(
+        folder: Option<&str>,
+        from_ts: Option<f64>,
+        to_ts: Option<f64>,
+        tags: Option<&'a [String]>,
+    ) -> Self {
+        Self {
+            folder_prefix: folder.map(normalize_folder_prefix),
+            from_ts,
+            to_ts,
+            tags,
+        }
+    }
+
+    pub(crate) fn matches(&self, doc: &Document) -> bool {
+        if !path_matches_folder_prefix(&doc.source_file, self.folder_prefix.as_deref(), true) {
+            return false;
+        }
+
+        if let Some(from) = self.from_ts
+            && doc.last_modified < from
+        {
+            return false;
+        }
+
+        if let Some(to) = self.to_ts
+            && doc.last_modified > to
+        {
+            return false;
+        }
+
+        if let Some(required_tags) = self.tags
+            && !tags_match(&doc.tags, required_tags)
+        {
+            return false;
+        }
+
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn doc(path: &str, ts: f64, tags: &[&str]) -> Document {
+        Document {
+            source_file: path.to_string(),
+            full_text: String::new(),
+            title: String::new(),
+            tags: tags.iter().map(|tag| tag.to_string()).collect(),
+            content_hash: String::new(),
+            last_modified: ts,
+            outgoing_links: vec![],
+            backlinks: vec![],
+        }
+    }
+
+    #[test]
+    fn filters_by_folder_date_and_tags() {
+        let required_tags = vec!["rust".to_string()];
+        let filters = DocumentFilters::new(
+            Some("journal/2026"),
+            Some(200.0),
+            Some(400.0),
+            Some(&required_tags),
+        );
+
+        assert!(filters.matches(&doc("journal/2026/today.md", 250.0, &["rust", "mcp"])));
+        assert!(!filters.matches(&doc("projects/idea.md", 250.0, &["rust"])));
+        assert!(!filters.matches(&doc("journal/2026/today.md", 450.0, &["rust"])));
+        assert!(!filters.matches(&doc("journal/2026/today.md", 250.0, &["notes"])));
+    }
+}

--- a/crates/mcp/src/filters/mod.rs
+++ b/crates/mcp/src/filters/mod.rs
@@ -1,5 +1,6 @@
 mod aggregate;
 mod browse;
+mod documents;
 mod edit;
 mod search;
 mod tags;
@@ -7,6 +8,7 @@ mod types;
 
 pub use aggregate::aggregate_tags;
 pub use browse::filter_browse_results;
+pub(crate) use documents::DocumentFilters;
 pub use edit::apply_tag_edits;
 pub use search::filter_search_results;
 pub use tags::tags_match;

--- a/crates/mcp/src/filters/search.rs
+++ b/crates/mcp/src/filters/search.rs
@@ -1,5 +1,4 @@
-use crate::filters::tags_match;
-use kajet_core::path_utils::{normalize_folder_prefix, path_matches_folder_prefix};
+use crate::filters::DocumentFilters;
 use kajet_core::search::SearchResult;
 use kajet_core::types::Document;
 use std::collections::HashMap;
@@ -19,36 +18,14 @@ pub fn filter_search_results(
 ) {
     let doc_map: HashMap<&str, &Document> =
         docs.iter().map(|d| (d.source_file.as_str(), d)).collect();
-    let folder_prefix = folder.map(normalize_folder_prefix);
+    let filters = DocumentFilters::new(folder, from_ts, to_ts, tags);
 
     results.retain(|result| {
-        if !path_matches_folder_prefix(&result.note_path, folder_prefix.as_deref(), true) {
-            return false;
-        }
-
         let Some(doc) = doc_map.get(result.note_path.as_str()) else {
             return false;
         };
 
-        if let Some(from) = from_ts
-            && doc.last_modified < from
-        {
-            return false;
-        }
-
-        if let Some(to) = to_ts
-            && doc.last_modified > to
-        {
-            return false;
-        }
-
-        if let Some(required_tags) = tags
-            && !tags_match(&doc.tags, required_tags)
-        {
-            return false;
-        }
-
-        true
+        filters.matches(doc)
     });
 
     results.truncate(limit);

--- a/crates/mcp/src/format/explore_connections.rs
+++ b/crates/mcp/src/format/explore_connections.rs
@@ -1,0 +1,137 @@
+use crate::use_cases::explore_connections::{ExploreConnectionsView, ExploreNodeView};
+
+pub(crate) fn format_explore_connections(view: &ExploreConnectionsView) -> String {
+    let mut lines = vec![
+        t!(
+            "explore_header",
+            path = view.start_path.as_str(),
+            depth = view.depth_limit,
+            limit = view.node_limit,
+            mode = view.filter_mode.as_str(),
+            dedup = view.dedup
+        )
+        .to_string(),
+        String::new(),
+    ];
+
+    render_node(&view.root, 0, &mut lines);
+    lines.push(String::new());
+
+    if view.filtered_results_empty {
+        lines.push(t!("explore_no_filtered_results").to_string());
+    }
+
+    if view.shown_nodes == view.unique_nodes {
+        lines.push(
+            t!(
+                "explore_summary",
+                unique = view.unique_nodes,
+                depth = view.max_depth_reached
+            )
+            .to_string(),
+        );
+    } else {
+        lines.push(
+            t!(
+                "explore_summary_with_shown",
+                unique = view.unique_nodes,
+                shown = view.shown_nodes,
+                depth = view.max_depth_reached
+            )
+            .to_string(),
+        );
+    }
+
+    if view.truncated {
+        lines.push(t!("explore_limit_reached", limit = view.node_limit).to_string());
+    }
+
+    lines.join("\n")
+}
+
+fn render_node(node: &ExploreNodeView, indent: usize, out: &mut Vec<String>) {
+    let prefix = "  ".repeat(indent);
+    let cycle = if node.cycle {
+        t!("explore_cycle_suffix").to_string()
+    } else {
+        String::new()
+    };
+
+    let line = if let Some(direction) = node.direction {
+        format!(
+            "{prefix}{} {} (depth {}, {} connections{})",
+            direction.arrow(),
+            node.path,
+            node.depth,
+            node.degree,
+            cycle
+        )
+    } else {
+        format!(
+            "{prefix}{} ({} connections{})",
+            node.path, node.degree, cycle
+        )
+    };
+
+    out.push(line);
+
+    if let Some(section) = &node.context {
+        out.push(format!(
+            "{}  {}",
+            prefix,
+            t!("explore_section", section = section.as_str())
+        ));
+    }
+
+    for child in &node.children {
+        render_node(child, indent + 1, out);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::explore_input::ExploreFilterMode;
+    use crate::use_cases::explore_connections::{ConnectionDirection, ExploreNodeView};
+
+    #[test]
+    fn formats_tree_with_context_and_cycle_marker() {
+        rust_i18n::set_locale("en");
+
+        let view = ExploreConnectionsView {
+            start_path: "topic-a.md".to_string(),
+            depth_limit: 2,
+            node_limit: 50,
+            filter_mode: ExploreFilterMode::Display,
+            dedup: true,
+            root: ExploreNodeView {
+                path: "topic-a.md".to_string(),
+                depth: 0,
+                degree: 2,
+                direction: None,
+                context: None,
+                cycle: false,
+                children: vec![ExploreNodeView {
+                    path: "hub-note.md".to_string(),
+                    depth: 1,
+                    degree: 5,
+                    direction: Some(ConnectionDirection::Backlink),
+                    context: Some("Core concepts".to_string()),
+                    cycle: true,
+                    children: vec![],
+                }],
+            },
+            unique_nodes: 2,
+            shown_nodes: 2,
+            max_depth_reached: 1,
+            truncated: false,
+            filtered_results_empty: false,
+        };
+
+        let text = format_explore_connections(&view);
+        assert!(text.contains("Exploring connections from: topic-a.md"));
+        assert!(text.contains("← hub-note.md"));
+        assert!(text.contains("section: \"Core concepts\""));
+        assert!(text.contains("cycle detected"));
+    }
+}

--- a/crates/mcp/src/format/mod.rs
+++ b/crates/mcp/src/format/mod.rs
@@ -1,6 +1,7 @@
 mod analytics;
 mod entries;
 mod examine;
+mod explore_connections;
 mod notes;
 mod search;
 mod tags;
@@ -13,6 +14,7 @@ pub use tree::{format_tree_too_large, format_vault_tree};
 
 pub(crate) use analytics::{RecentContextEntryView, RecentContextView, format_recent_context};
 pub(crate) use examine::{ExamineBatchSection, format_examine_batch, format_examine_result};
+pub(crate) use explore_connections::format_explore_connections;
 pub(crate) use tags::format_list_tags;
 
 #[cfg(test)]

--- a/crates/mcp/src/handlers/documents.rs
+++ b/crates/mcp/src/handlers/documents.rs
@@ -1,9 +1,30 @@
 use crate::domain::documents_input::prepare_examine_input;
+use crate::domain::explore_input::{ExploreInputError, prepare_explore_connections_input};
 use crate::errors::internal_error;
-use crate::schema::ExamineRequest;
+use crate::schema::{ExamineRequest, ExploreConnectionsRequest};
 use crate::use_cases::documents::execute_examine;
+use crate::use_cases::explore_connections::execute_explore_connections;
 use rmcp::{handler::server::wrapper::Parameters, model::*, tool, tool_router};
 use tracing::instrument;
+
+fn map_explore_input_error(err: ExploreInputError) -> ErrorData {
+    match err {
+        ExploreInputError::EmptyPath => internal_error(t!("explore_path_required").to_string()),
+        ExploreInputError::DepthZero => internal_error(t!("explore_depth_zero").to_string()),
+        ExploreInputError::LimitZero => internal_error(t!("explore_limit_zero").to_string()),
+        ExploreInputError::DateParse { input, error } => {
+            internal_error(t!("explore_date_parse_error", input = input, error = error).to_string())
+        }
+        ExploreInputError::InvalidDateRange { from, to } => internal_error(
+            t!(
+                "explore_date_range_error",
+                from = from.to_string(),
+                to = to.to_string()
+            )
+            .to_string(),
+        ),
+    }
+}
 
 #[tool_router(router = tool_router_documents, vis = "pub(crate)")]
 impl crate::KajetMcp {
@@ -28,6 +49,49 @@ impl crate::KajetMcp {
         )
         .await
         .map_err(|e| internal_error(e.to_string()))?;
+
+        Ok(CallToolResult::success(vec![Content::text(out.summary)]))
+    }
+
+    #[tool(
+        description = "Explore note connections as a traversal tree. Supports depth/limit, deduplication, optional section context, and filter modes ('display' or 'traverse')."
+    )]
+    #[instrument(
+        level = "debug",
+        skip(self, params),
+        fields(path, depth, limit, dedup, include_context, filter_mode)
+    )]
+    async fn explore_connections(
+        &self,
+        params: Parameters<ExploreConnectionsRequest>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let req = params.0;
+        let defaults = {
+            let config = self.state.config.read().unwrap();
+            config.mcp.explore_connections.clone()
+        };
+
+        let input =
+            prepare_explore_connections_input(req, &defaults, chrono::Local::now().date_naive())
+                .map_err(map_explore_input_error)?;
+
+        let span = tracing::Span::current();
+        span.record("path", input.path.as_str());
+        span.record("depth", input.depth);
+        span.record("limit", input.limit);
+        span.record("dedup", input.dedup);
+        span.record("include_context", input.include_context);
+        span.record("filter_mode", input.filter_mode.as_str());
+
+        let start = std::time::Instant::now();
+        let out = execute_explore_connections(self, input)
+            .await
+            .map_err(|e| internal_error(t!("explore_failed", error = e.to_string()).to_string()))?;
+
+        tracing::info!(
+            elapsed_ms = start.elapsed().as_millis() as u64,
+            "MCP explore_connections"
+        );
 
         Ok(CallToolResult::success(vec![Content::text(out.summary)]))
     }

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -19,8 +19,8 @@ pub use format::{
     format_results, format_tree_too_large, format_vault_tree,
 };
 pub use schema::{
-    CreateNoteRequest, EditNoteRequest, EditTagsRequest, ExamineRequest, ListTagsRequest,
-    RecentContextRequest, ReindexRequest, SearchRequest, TreeRequest,
+    CreateNoteRequest, EditNoteRequest, EditTagsRequest, ExamineRequest, ExploreConnectionsRequest,
+    ListTagsRequest, RecentContextRequest, ReindexRequest, SearchRequest, TreeRequest,
 };
 
 use anyhow::Result;

--- a/crates/mcp/src/ports.rs
+++ b/crates/mcp/src/ports.rs
@@ -1,6 +1,7 @@
 use crate::domain::search_input::SearchMode;
 use kajet_core::actions::{ActionEvent, SearchResultSummary};
 use kajet_core::search::{ExamineManyResult, SearchResult};
+use kajet_core::traits::StoredChunk;
 use kajet_core::types::{Document, IndexStats};
 use std::path::{Path, PathBuf};
 
@@ -253,6 +254,29 @@ pub(crate) trait DocumentsPorts {
 impl DocumentsPorts for crate::KajetMcp {
     async fn examine_many(&self, paths: &[String]) -> anyhow::Result<Vec<ExamineManyResult>> {
         self.state.search_engine.examine_many(paths).await
+    }
+}
+
+pub(crate) trait ExploreConnectionsPorts {
+    async fn get_all_documents(&self) -> anyhow::Result<Vec<Document>>;
+    async fn get_chunks_by_path(&self, note_path: &str) -> anyhow::Result<Vec<StoredChunk>>;
+}
+
+impl ExploreConnectionsPorts for crate::KajetMcp {
+    async fn get_all_documents(&self) -> anyhow::Result<Vec<Document>> {
+        self.state
+            .search_engine
+            .doc_store()
+            .get_all_documents()
+            .await
+    }
+
+    async fn get_chunks_by_path(&self, note_path: &str) -> anyhow::Result<Vec<StoredChunk>> {
+        self.state
+            .search_engine
+            .store()
+            .get_chunks_by_path(note_path)
+            .await
     }
 }
 

--- a/crates/mcp/src/schema.rs
+++ b/crates/mcp/src/schema.rs
@@ -33,6 +33,57 @@ pub struct ExamineRequest {
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct ExploreConnectionsRequest {
+    /// Starting note path (full/partial/filename)
+    #[schemars(
+        description = "Starting note path — full relative path or partial (filename). Fuzzy suffix matching is used if exact match fails."
+    )]
+    pub path: String,
+
+    /// Maximum traversal depth
+    #[schemars(description = "Maximum traversal depth (default: from config)")]
+    pub depth: Option<usize>,
+
+    /// Maximum total nodes to include in output
+    #[schemars(description = "Maximum total nodes in output (default: from config)")]
+    pub limit: Option<usize>,
+
+    /// Show each node once or allow repeated nodes on different paths
+    #[schemars(description = "Deduplicate nodes (default: true). false shows repeated nodes.")]
+    pub dedup: Option<bool>,
+
+    /// Include section context where link appears
+    #[schemars(description = "Include section context where the link appears (default: false).")]
+    pub include_context: Option<bool>,
+
+    /// Filter mode: display or traverse
+    #[schemars(
+        description = "Filter mode: 'display' (traverse full graph, filter shown nodes) or 'traverse' (only traverse matching nodes)."
+    )]
+    pub filter_mode: Option<String>,
+
+    /// Filter by tags (all required)
+    #[schemars(description = "Filter by tags. Documents must have ALL specified tags.")]
+    pub tags: Option<Vec<String>>,
+
+    /// Filter by date range start
+    #[schemars(
+        description = "Date filter start. Formats: ISO (2025-01-15, 2025-01), Polish/English keywords like 'dzisiaj', 'wczoraj', 'today', 'last week'."
+    )]
+    pub from: Option<String>,
+
+    /// Filter by date range end
+    #[schemars(description = "Date filter end. Same formats as 'from'.")]
+    pub to: Option<String>,
+
+    /// Filter by folder path prefix
+    #[schemars(
+        description = "Filter by folder path prefix, e.g. 'journal/2025'. Matches documents in this folder and subfolders."
+    )]
+    pub folder: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct SearchRequest {
     /// The search query (optional if filters provided)
     #[schemars(

--- a/crates/mcp/src/use_cases/explore_connections.rs
+++ b/crates/mcp/src/use_cases/explore_connections.rs
@@ -1,0 +1,619 @@
+use crate::domain::explore_input::{ExploreConnectionsInput, ExploreFilterMode};
+use crate::filters::DocumentFilters;
+use crate::format::format_explore_connections;
+use crate::ports::ExploreConnectionsPorts;
+use kajet_core::search::resolve_examine_document;
+use kajet_core::traits::StoredChunk;
+use kajet_core::types::Document;
+use std::collections::{HashMap, HashSet, VecDeque};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ConnectionDirection {
+    Backlink,
+    Outgoing,
+    Both,
+}
+
+impl ConnectionDirection {
+    fn merge(self, other: ConnectionDirection) -> ConnectionDirection {
+        match (self, other) {
+            (Self::Both, _) | (_, Self::Both) => Self::Both,
+            (Self::Backlink, Self::Outgoing) | (Self::Outgoing, Self::Backlink) => Self::Both,
+            (same, _) => same,
+        }
+    }
+
+    pub(crate) fn arrow(self) -> &'static str {
+        match self {
+            Self::Backlink => "←",
+            Self::Outgoing => "→",
+            Self::Both => "↔",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ExploreNodeView {
+    pub path: String,
+    pub depth: usize,
+    pub degree: usize,
+    pub direction: Option<ConnectionDirection>,
+    pub context: Option<String>,
+    pub cycle: bool,
+    pub children: Vec<ExploreNodeView>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ExploreConnectionsView {
+    pub start_path: String,
+    pub depth_limit: usize,
+    pub node_limit: usize,
+    pub filter_mode: ExploreFilterMode,
+    pub dedup: bool,
+    pub root: ExploreNodeView,
+    pub unique_nodes: usize,
+    pub shown_nodes: usize,
+    pub max_depth_reached: usize,
+    pub truncated: bool,
+    pub filtered_results_empty: bool,
+}
+
+pub(crate) struct ExploreConnectionsOutput {
+    pub summary: String,
+}
+
+#[derive(Debug, Clone)]
+struct TempNode {
+    path: String,
+    depth: usize,
+    degree: usize,
+    direction: Option<ConnectionDirection>,
+    context: Option<String>,
+    cycle: bool,
+    children: Vec<usize>,
+}
+
+#[derive(Debug, Clone)]
+struct NeighborEdge {
+    path: String,
+    direction: ConnectionDirection,
+    degree: usize,
+}
+
+#[derive(Debug, Clone)]
+struct QueueItem {
+    path: String,
+    depth: usize,
+    output_idx: Option<usize>,
+    anchor_idx: usize,
+    ancestors: Vec<String>,
+}
+
+pub(crate) async fn execute_explore_connections(
+    ports: &impl ExploreConnectionsPorts,
+    input: ExploreConnectionsInput,
+) -> anyhow::Result<ExploreConnectionsOutput> {
+    let view = build_explore_connections_view(ports, &input).await?;
+    Ok(ExploreConnectionsOutput {
+        summary: format_explore_connections(&view),
+    })
+}
+
+async fn build_explore_connections_view(
+    ports: &impl ExploreConnectionsPorts,
+    input: &ExploreConnectionsInput,
+) -> anyhow::Result<ExploreConnectionsView> {
+    let docs = ports.get_all_documents().await?;
+    let start_doc = resolve_examine_document(&docs, &input.path)?;
+    let start_path = start_doc.source_file.clone();
+
+    let docs_by_path: HashMap<&str, &Document> = docs
+        .iter()
+        .map(|doc| (doc.source_file.as_str(), doc))
+        .collect();
+    let known_paths: HashSet<&str> = docs_by_path.keys().copied().collect();
+    let degree_map = build_degree_map(&docs, &known_paths);
+
+    let root_degree = degree_map.get(start_path.as_str()).copied().unwrap_or(0);
+    let mut nodes = vec![TempNode {
+        path: start_path.clone(),
+        depth: 0,
+        degree: root_degree,
+        direction: None,
+        context: None,
+        cycle: false,
+        children: Vec::new(),
+    }];
+
+    let filters = DocumentFilters::new(
+        input.folder.as_deref(),
+        input.from_ts,
+        input.to_ts,
+        input.tags.as_deref(),
+    );
+    let has_filters = input.folder.is_some()
+        || input.from_ts.is_some()
+        || input.to_ts.is_some()
+        || input
+            .tags
+            .as_ref()
+            .map(|tags| !tags.is_empty())
+            .unwrap_or(false);
+    let root_matches_filter = filters.matches(start_doc);
+
+    if matches!(input.filter_mode, ExploreFilterMode::Traverse)
+        && has_filters
+        && !root_matches_filter
+    {
+        let root = materialize_tree(&nodes, 0);
+        return Ok(ExploreConnectionsView {
+            start_path,
+            depth_limit: input.depth,
+            node_limit: input.limit,
+            filter_mode: input.filter_mode,
+            dedup: input.dedup,
+            root,
+            unique_nodes: 1,
+            shown_nodes: 1,
+            max_depth_reached: 0,
+            truncated: false,
+            filtered_results_empty: true,
+        });
+    }
+
+    let mut shown_nodes = 1usize;
+    let mut unique_nodes: HashSet<String> = HashSet::from([start_path.clone()]);
+    let mut matched_visible_nodes: HashSet<String> = HashSet::new();
+    if root_matches_filter {
+        matched_visible_nodes.insert(start_path.clone());
+    }
+    let mut max_depth_reached = 0usize;
+    let mut truncated = false;
+    let mut seen_global: HashSet<String> = HashSet::new();
+    if input.dedup {
+        seen_global.insert(start_path.clone());
+    }
+
+    let mut queue = VecDeque::new();
+    queue.push_back(QueueItem {
+        path: start_path.clone(),
+        depth: 0,
+        output_idx: Some(0),
+        anchor_idx: 0,
+        ancestors: vec![start_path.clone()],
+    });
+
+    let mut context_cache = EdgeContextCache::new(ports);
+
+    while let Some(item) = queue.pop_front() {
+        if item.depth >= input.depth {
+            continue;
+        }
+
+        let Some(current_doc) = docs_by_path.get(item.path.as_str()) else {
+            continue;
+        };
+
+        let neighbors = build_neighbors(current_doc, &known_paths, &degree_map);
+        for neighbor in neighbors {
+            if truncated {
+                break;
+            }
+
+            let Some(candidate_doc) = docs_by_path.get(neighbor.path.as_str()) else {
+                continue;
+            };
+            let matches_filter = filters.matches(candidate_doc);
+            if matches!(input.filter_mode, ExploreFilterMode::Traverse) && !matches_filter {
+                continue;
+            }
+
+            let cycle_on_path = item.ancestors.iter().any(|path| path == &neighbor.path);
+            let revisited = input.dedup && seen_global.contains(&neighbor.path);
+            let cycle = cycle_on_path || revisited;
+
+            let should_display = if neighbor.path == start_path {
+                let root_cycle_allowed = !has_filters || root_matches_filter;
+                item.output_idx.is_some() && root_cycle_allowed
+            } else {
+                match input.filter_mode {
+                    ExploreFilterMode::Display => matches_filter,
+                    ExploreFilterMode::Traverse => true,
+                }
+            };
+
+            let parent_idx = item.output_idx.unwrap_or(item.anchor_idx);
+            let mut next_output_idx = None;
+            let mut next_anchor_idx = item.anchor_idx;
+
+            if should_display {
+                if shown_nodes >= input.limit {
+                    truncated = true;
+                    break;
+                }
+
+                let context = if input.include_context {
+                    context_cache
+                        .context_for_edge(&item.path, &neighbor.path, neighbor.direction)
+                        .await
+                } else {
+                    None
+                };
+
+                let idx = nodes.len();
+                nodes.push(TempNode {
+                    path: neighbor.path.clone(),
+                    depth: item.depth + 1,
+                    degree: neighbor.degree,
+                    direction: Some(neighbor.direction),
+                    context,
+                    cycle,
+                    children: Vec::new(),
+                });
+                nodes[parent_idx].children.push(idx);
+                shown_nodes += 1;
+                unique_nodes.insert(neighbor.path.clone());
+                if matches_filter {
+                    matched_visible_nodes.insert(neighbor.path.clone());
+                }
+                max_depth_reached = max_depth_reached.max(item.depth + 1);
+
+                next_output_idx = Some(idx);
+                next_anchor_idx = idx;
+            } else if !cycle {
+                max_depth_reached = max_depth_reached.max(item.depth + 1);
+            }
+
+            if cycle {
+                continue;
+            }
+
+            if input.dedup {
+                seen_global.insert(neighbor.path.clone());
+            }
+
+            if item.depth + 1 < input.depth {
+                let mut next_ancestors = item.ancestors.clone();
+                next_ancestors.push(neighbor.path.clone());
+                queue.push_back(QueueItem {
+                    path: neighbor.path,
+                    depth: item.depth + 1,
+                    output_idx: next_output_idx,
+                    anchor_idx: next_anchor_idx,
+                    ancestors: next_ancestors,
+                });
+            }
+        }
+    }
+
+    let root = materialize_tree(&nodes, 0);
+    Ok(ExploreConnectionsView {
+        start_path,
+        depth_limit: input.depth,
+        node_limit: input.limit,
+        filter_mode: input.filter_mode,
+        dedup: input.dedup,
+        root,
+        unique_nodes: unique_nodes.len(),
+        shown_nodes,
+        max_depth_reached,
+        truncated,
+        filtered_results_empty: has_filters && matched_visible_nodes.is_empty(),
+    })
+}
+
+fn materialize_tree(nodes: &[TempNode], idx: usize) -> ExploreNodeView {
+    let node = &nodes[idx];
+    ExploreNodeView {
+        path: node.path.clone(),
+        depth: node.depth,
+        degree: node.degree,
+        direction: node.direction,
+        context: node.context.clone(),
+        cycle: node.cycle,
+        children: node
+            .children
+            .iter()
+            .map(|child_idx| materialize_tree(nodes, *child_idx))
+            .collect(),
+    }
+}
+
+fn build_degree_map(docs: &[Document], known_paths: &HashSet<&str>) -> HashMap<String, usize> {
+    docs.iter()
+        .map(|doc| {
+            let mut neighbors = HashSet::new();
+            for target in &doc.outgoing_links {
+                if known_paths.contains(target.as_str()) {
+                    neighbors.insert(target.as_str());
+                }
+            }
+            for source in &doc.backlinks {
+                if known_paths.contains(source.as_str()) {
+                    neighbors.insert(source.as_str());
+                }
+            }
+            (doc.source_file.clone(), neighbors.len())
+        })
+        .collect()
+}
+
+fn build_neighbors(
+    doc: &Document,
+    known_paths: &HashSet<&str>,
+    degree_map: &HashMap<String, usize>,
+) -> Vec<NeighborEdge> {
+    let mut relation_map: HashMap<&str, ConnectionDirection> = HashMap::new();
+
+    for target in &doc.outgoing_links {
+        if !known_paths.contains(target.as_str()) {
+            continue;
+        }
+        relation_map
+            .entry(target.as_str())
+            .and_modify(|existing| *existing = existing.merge(ConnectionDirection::Outgoing))
+            .or_insert(ConnectionDirection::Outgoing);
+    }
+
+    for source in &doc.backlinks {
+        if !known_paths.contains(source.as_str()) {
+            continue;
+        }
+        relation_map
+            .entry(source.as_str())
+            .and_modify(|existing| *existing = existing.merge(ConnectionDirection::Backlink))
+            .or_insert(ConnectionDirection::Backlink);
+    }
+
+    let mut out: Vec<NeighborEdge> = relation_map
+        .into_iter()
+        .map(|(path, direction)| NeighborEdge {
+            path: path.to_string(),
+            direction,
+            degree: degree_map.get(path).copied().unwrap_or(0),
+        })
+        .collect();
+
+    out.sort_by(|a, b| b.degree.cmp(&a.degree).then_with(|| a.path.cmp(&b.path)));
+    out
+}
+
+struct EdgeContextCache<'a, P: ExploreConnectionsPorts> {
+    ports: &'a P,
+    by_source: HashMap<String, HashMap<String, String>>,
+}
+
+impl<'a, P: ExploreConnectionsPorts> EdgeContextCache<'a, P> {
+    fn new(ports: &'a P) -> Self {
+        Self {
+            ports,
+            by_source: HashMap::new(),
+        }
+    }
+
+    async fn context_for_edge(
+        &mut self,
+        from: &str,
+        to: &str,
+        direction: ConnectionDirection,
+    ) -> Option<String> {
+        let (source, target) = match direction {
+            ConnectionDirection::Outgoing | ConnectionDirection::Both => (from, to),
+            ConnectionDirection::Backlink => (to, from),
+        };
+
+        self.ensure_loaded(source).await;
+        self.by_source
+            .get(source)
+            .and_then(|m| m.get(target))
+            .cloned()
+    }
+
+    async fn ensure_loaded(&mut self, source: &str) {
+        if self.by_source.contains_key(source) {
+            return;
+        }
+
+        let chunks = match self.ports.get_chunks_by_path(source).await {
+            Ok(chunks) => chunks,
+            Err(error) => {
+                tracing::warn!(path = source, error = %error, "Failed to load chunks for edge context");
+                Vec::new()
+            }
+        };
+
+        let mut map = HashMap::new();
+        for chunk in chunks {
+            let Some(section) = section_from_breadcrumb(&chunk) else {
+                continue;
+            };
+            for link in chunk.links {
+                if let Some(target) = link.resolved_path {
+                    map.entry(target).or_insert_with(|| section.clone());
+                }
+            }
+        }
+
+        self.by_source.insert(source.to_string(), map);
+    }
+}
+
+fn section_from_breadcrumb(chunk: &StoredChunk) -> Option<String> {
+    let last = chunk.breadcrumb.rsplit(" > ").next()?.trim();
+    if last.is_empty() || last == chunk.note_path {
+        return None;
+    }
+    Some(last.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::explore_input::ExploreConnectionsInput;
+    use crate::domain::explore_input::ExploreFilterMode;
+    use crate::ports::ExploreConnectionsPorts;
+    use kajet_core::traits::StoredChunk;
+
+    #[derive(Clone)]
+    struct FakeExplorePorts {
+        docs: Vec<Document>,
+        chunks: HashMap<String, Vec<StoredChunk>>,
+    }
+
+    impl ExploreConnectionsPorts for FakeExplorePorts {
+        async fn get_all_documents(&self) -> anyhow::Result<Vec<Document>> {
+            Ok(self.docs.clone())
+        }
+
+        async fn get_chunks_by_path(&self, note_path: &str) -> anyhow::Result<Vec<StoredChunk>> {
+            Ok(self.chunks.get(note_path).cloned().unwrap_or_default())
+        }
+    }
+
+    fn doc(path: &str, tags: &[&str], outgoing: &[&str], backlinks: &[&str], ts: f64) -> Document {
+        Document {
+            source_file: path.to_string(),
+            full_text: String::new(),
+            title: path.to_string(),
+            tags: tags.iter().map(|tag| tag.to_string()).collect(),
+            content_hash: "hash".to_string(),
+            last_modified: ts,
+            outgoing_links: outgoing.iter().map(|p| p.to_string()).collect(),
+            backlinks: backlinks.iter().map(|p| p.to_string()).collect(),
+        }
+    }
+
+    fn input(path: &str) -> ExploreConnectionsInput {
+        ExploreConnectionsInput {
+            path: path.to_string(),
+            depth: 3,
+            limit: 50,
+            dedup: true,
+            include_context: false,
+            filter_mode: ExploreFilterMode::Display,
+            from_ts: None,
+            to_ts: None,
+            folder: None,
+            tags: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn traversal_orders_neighbors_by_degree() {
+        let ports = FakeExplorePorts {
+            docs: vec![
+                doc("a.md", &[], &["b.md"], &["c.md"], 100.0),
+                doc("b.md", &[], &[], &["a.md", "d.md"], 100.0),
+                doc("c.md", &[], &["a.md"], &[], 100.0),
+                doc("d.md", &[], &["b.md"], &[], 100.0),
+            ],
+            chunks: HashMap::new(),
+        };
+        let out = execute_explore_connections(&ports, input("a.md"))
+            .await
+            .expect("ok");
+
+        let b_pos = out.summary.find("b.md").expect("contains b.md");
+        let c_pos = out.summary.find("c.md").expect("contains c.md");
+        assert!(b_pos < c_pos, "higher-degree node should be shown first");
+    }
+
+    #[tokio::test]
+    async fn display_mode_traverses_through_filtered_nodes() {
+        let ports = FakeExplorePorts {
+            docs: vec![
+                doc("a.md", &["keep"], &["b.md"], &[], 100.0),
+                doc("b.md", &["skip"], &["c.md"], &["a.md"], 100.0),
+                doc("c.md", &["keep"], &[], &["b.md"], 100.0),
+            ],
+            chunks: HashMap::new(),
+        };
+        let mut req = input("a.md");
+        req.depth = 2;
+        req.tags = Some(vec!["keep".to_string()]);
+        req.filter_mode = ExploreFilterMode::Display;
+
+        let out = execute_explore_connections(&ports, req).await.expect("ok");
+
+        assert!(out.summary.contains("a.md"));
+        assert!(!out.summary.contains("b.md"));
+        assert!(out.summary.contains("c.md"));
+    }
+
+    #[tokio::test]
+    async fn include_context_uses_chunk_breadcrumbs() {
+        let ports = FakeExplorePorts {
+            docs: vec![
+                doc("a.md", &[], &["b.md"], &[], 100.0),
+                doc("b.md", &[], &[], &["a.md"], 100.0),
+            ],
+            chunks: HashMap::from([(
+                "a.md".to_string(),
+                vec![StoredChunk {
+                    note_path: "a.md".to_string(),
+                    breadcrumb: "a.md > Core concepts".to_string(),
+                    content: String::new(),
+                    raw_content: String::new(),
+                    vector: vec![0.0, 0.0],
+                    chunk_index: 0,
+                    content_hash: "hash".to_string(),
+                    links: vec![kajet_parser::Link {
+                        target: "b".to_string(),
+                        alias: None,
+                        resolved_path: Some("b.md".to_string()),
+                    }],
+                }],
+            )]),
+        };
+
+        let mut req = input("a.md");
+        req.depth = 1;
+        req.include_context = true;
+
+        let out = execute_explore_connections(&ports, req).await.expect("ok");
+        assert!(out.summary.contains("Core concepts"));
+    }
+
+    #[tokio::test]
+    async fn dedup_false_shows_node_on_multiple_paths() {
+        let ports = FakeExplorePorts {
+            docs: vec![
+                doc("a.md", &[], &["b.md", "c.md"], &[], 100.0),
+                doc("b.md", &[], &["d.md"], &["a.md"], 100.0),
+                doc("c.md", &[], &["d.md"], &["a.md"], 100.0),
+                doc("d.md", &[], &[], &["b.md", "c.md"], 100.0),
+            ],
+            chunks: HashMap::new(),
+        };
+
+        let mut req = input("a.md");
+        req.depth = 2;
+        req.dedup = false;
+
+        let out = execute_explore_connections(&ports, req).await.expect("ok");
+        let d_count = out.summary.match_indices("d.md").count();
+        assert!(d_count >= 2, "d.md should appear on both branches");
+    }
+
+    #[tokio::test]
+    async fn display_mode_with_non_matching_filters_has_no_phantom_root_cycles() {
+        let ports = FakeExplorePorts {
+            docs: vec![
+                doc("a.md", &["one"], &["b.md"], &["b.md"], 100.0),
+                doc("b.md", &["two"], &["a.md"], &["a.md"], 100.0),
+            ],
+            chunks: HashMap::new(),
+        };
+
+        let mut req = input("a.md");
+        req.depth = 2;
+        req.tags = Some(vec!["missing".to_string()]);
+        req.filter_mode = ExploreFilterMode::Display;
+
+        let out = execute_explore_connections(&ports, req).await.expect("ok");
+        assert!(out.summary.contains("No connections match active filters."));
+        assert!(!out.summary.contains("← a.md"));
+        assert!(!out.summary.contains("→ a.md"));
+        assert!(!out.summary.contains("↔ a.md"));
+    }
+}

--- a/crates/mcp/src/use_cases/mod.rs
+++ b/crates/mcp/src/use_cases/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod analytics;
 pub(crate) mod documents;
+pub(crate) mod explore_connections;
 pub(crate) mod index;
 pub(crate) mod notes;
 pub(crate) mod search;

--- a/locales/en.toml
+++ b/locales/en.toml
@@ -113,6 +113,21 @@ examine_batch_header = "Examined %{count} documents:"
 examine_batch_separator = "=== %{path} ==="
 examine_batch_error = "ERROR: %{error}"
 
+# MCP — explore_connections tool
+explore_path_required = "Path is required"
+explore_depth_zero = "depth must be at least 1"
+explore_limit_zero = "limit must be at least 1"
+explore_date_parse_error = "Unable to parse date '%{input}': %{error}"
+explore_date_range_error = "'from' date (%{from}) must be before or equal to 'to' date (%{to})"
+explore_failed = "Connection traversal failed: %{error}"
+explore_header = "Exploring connections from: %{path} (depth: %{depth}, limit: %{limit}, mode: %{mode}, dedup: %{dedup})"
+explore_section = "section: \"%{section}\""
+explore_cycle_suffix = " (cycle detected)"
+explore_no_filtered_results = "No connections match active filters."
+explore_summary = "Nodes: %{unique} unique, max depth reached: %{depth}"
+explore_summary_with_shown = "Nodes: %{unique} unique, %{shown} shown, max depth reached: %{depth}"
+explore_limit_reached = "Traversal stopped early after reaching node limit (%{limit})."
+
 # MCP — create_note / edit_note tools
 create_note_success = "Created note: %{path} (%{bytes} bytes)"
 create_note_failed = "Failed to create note: %{error}"

--- a/locales/pl.toml
+++ b/locales/pl.toml
@@ -113,6 +113,21 @@ examine_batch_header = "Przeanalizowano %{count} dokumentów:"
 examine_batch_separator = "=== %{path} ==="
 examine_batch_error = "BŁĄD: %{error}"
 
+# MCP — narzędzie explore_connections
+explore_path_required = "Pole 'path' jest wymagane"
+explore_depth_zero = "depth musi być co najmniej 1"
+explore_limit_zero = "limit musi być co najmniej 1"
+explore_date_parse_error = "Nie można sparsować daty '%{input}': %{error}"
+explore_date_range_error = "Data 'from' (%{from}) musi być wcześniejsza lub równa dacie 'to' (%{to})"
+explore_failed = "Eksploracja połączeń nie powiodła się: %{error}"
+explore_header = "Eksploruję połączenia od: %{path} (depth: %{depth}, limit: %{limit}, tryb: %{mode}, dedup: %{dedup})"
+explore_section = "sekcja: \"%{section}\""
+explore_cycle_suffix = " (wykryto cykl)"
+explore_no_filtered_results = "Brak połączeń spełniających aktywne filtry."
+explore_summary = "Węzły: %{unique} unikalnych, osiągnięta maks. głębokość: %{depth}"
+explore_summary_with_shown = "Węzły: %{unique} unikalnych, %{shown} pokazanych, osiągnięta maks. głębokość: %{depth}"
+explore_limit_reached = "Przerwano wcześniej po osiągnięciu limitu węzłów (%{limit})."
+
 # MCP — narzędzia create_note / edit_note
 create_note_success = "Utworzono notatkę: %{path} (%{bytes} bajtów)"
 create_note_failed = "Nie udało się utworzyć notatki: %{error}"


### PR DESCRIPTION
## Summary
- add new MCP tool explore_connections for graph traversal with depth/limit/dedup and filter modes display/traverse
- add reusable document filtering predicate and expose fuzzy path resolver for reuse
- add section-context rendering, i18n messages (PL/EN), config defaults under mcp.explore_connections, and docs updates
- fix phantom self-cycle output when filters return no matches and show clear no-results message

## Testing
- cargo nextest run -p kajet-core -p kajet-mcp
- pre-push hooks passed (core/parser tests, frontend check/build, cargo machete)

Closes #74