### PR TITLE
refactor(parser): filter boilerplate sections from chunker (closes #49)

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -75,6 +75,7 @@ kajet-web           — Axum HTTP + WebSocket, embedded Svelte frontend (rust-em
 - **TRACE** — Raw data only, for debugging embedding/search quality: embedding vectors (`first_5=[0.023, -0.11, ...]`), token IDs, raw chunk content. Never timings.
 - **ERROR** — Unrecoverable file/operation failures. **WARN** — Best-effort operations that failed (backlinks, FTS index).
 - Tests: test behavior and edge cases, not that code compiles. Each test has a clear reason to exist. Use mocks from `kajet-core::traits::mocks`.
+- **Test data**: All test fixtures should use anonymized content loosely inspired by Disco Elysium world (Revachol, RCM, Martinaise, etc.). Never use real personal data in tests.
 - Trait-based DI: `Engine` accepts `Box<dyn Embedder>` + `Box<dyn VectorStore>` — preserve this for testability.
 
 **Performance mindset:**

--- a/crates/backend/src/metadata.rs
+++ b/crates/backend/src/metadata.rs
@@ -5,7 +5,8 @@ use std::path::Path;
 /// Bump this when storage format changes require a full reindex.
 /// Version 2: Added chunk_index column to search results
 /// Version 3: Fixed chunk_index type from UInt32 to Int64
-pub const CURRENT_SCHEMA_VERSION: u32 = 3;
+/// Version 4: Chunker refactored — changelog/boilerplate sections excluded from index
+pub const CURRENT_SCHEMA_VERSION: u32 = 4;
 
 fn default_embedding_backend() -> String {
     "candle".to_string()

--- a/crates/parser/src/chunker.rs
+++ b/crates/parser/src/chunker.rs
@@ -1,133 +1,154 @@
+use crate::section_filter::should_skip_section;
+use crate::sections::{Section, parse_sections};
 use crate::types::{Chunk, ChunkConfig};
 use crate::wikilinks::{extract_wikilinks, resolve_wikilinks_in_text};
-use pulldown_cmark::{Event, HeadingLevel, Parser, Tag, TagEnd};
+use pulldown_cmark::{Event, HeadingLevel, Parser, TagEnd};
 
-pub fn chunk_markdown(note_path: &str, markdown: &str, config: &ChunkConfig) -> Vec<Chunk> {
+/// Extract clean text from a raw markdown slice using pulldown-cmark events.
+/// Mirrors the text accumulation logic of the original chunker.
+fn extract_text(markdown: &str) -> String {
     let parser = Parser::new(markdown);
-    let mut raw_sections = Vec::new();
-
-    let mut heading_stack: Vec<(u8, String)> = Vec::new();
-    let mut current_text = String::new();
-    let mut in_heading = false;
-    let mut current_heading_text = String::new();
-    let mut current_heading_level: u8 = 0;
-
+    let mut text = String::new();
     for event in parser {
         match event {
-            Event::Start(Tag::Heading { level, .. }) => {
-                flush_section(note_path, &heading_stack, &current_text, &mut raw_sections);
-                current_text.clear();
-
-                in_heading = true;
-                current_heading_text.clear();
-                current_heading_level = heading_level_to_u8(level);
-            }
-            Event::End(TagEnd::Heading(_)) => {
-                in_heading = false;
-
-                while heading_stack
-                    .last()
-                    .is_some_and(|(l, _)| *l >= current_heading_level)
-                {
-                    heading_stack.pop();
-                }
-                heading_stack.push((current_heading_level, current_heading_text.clone()));
-            }
-            Event::Text(text) | Event::Code(text) => {
-                if in_heading {
-                    current_heading_text.push_str(&text);
-                } else {
-                    current_text.push_str(&text);
-                }
-            }
-            Event::SoftBreak | Event::HardBreak => {
-                if !in_heading {
-                    current_text.push('\n');
-                }
-            }
-            Event::End(TagEnd::Paragraph) => {
-                current_text.push_str("\n\n");
-            }
-            Event::End(TagEnd::Item) => {
-                current_text.push('\n');
-            }
+            Event::Text(t) | Event::Code(t) => text.push_str(&t),
+            Event::SoftBreak | Event::HardBreak => text.push('\n'),
+            Event::End(TagEnd::Paragraph) => text.push_str("\n\n"),
+            Event::End(TagEnd::Item) => text.push('\n'),
             _ => {}
         }
     }
+    text
+}
 
-    flush_section(note_path, &heading_stack, &current_text, &mut raw_sections);
+/// Build hierarchical breadcrumbs from a flat section list.
+/// E.g. [H1, H2, H3] → ["note.md > H1", "note.md > H1 > H2", "note.md > H1 > H2 > H3"]
+fn build_breadcrumbs(note_path: &str, sections: &[Section]) -> Vec<String> {
+    let mut stack: Vec<(u8, &str)> = Vec::new();
+    sections
+        .iter()
+        .map(|s| {
+            while stack.last().is_some_and(|(l, _)| *l >= s.level) {
+                stack.pop();
+            }
+            stack.push((s.level, &s.heading_text));
+            let path: Vec<&str> = stack.iter().map(|(_, h)| *h).collect();
+            format!("{} > {}", note_path, path.join(" > "))
+        })
+        .collect()
+}
 
-    // Now split oversized sections and apply wikilink processing
+/// Compute "direct body" byte ranges: from heading end to next heading start (any level).
+/// Returns (start, end) pairs for each section.
+fn direct_body_ranges(sections: &[Section], doc_len: usize) -> Vec<(usize, usize)> {
+    sections
+        .iter()
+        .enumerate()
+        .map(|(i, s)| {
+            let start = s.heading_range.end;
+            let end = sections
+                .get(i + 1)
+                .map(|next| next.heading_range.start)
+                .unwrap_or(doc_len);
+            (start, end)
+        })
+        .collect()
+}
+
+/// Create a Chunk with wikilink processing.
+fn make_chunk(
+    note_path: &str,
+    breadcrumb: String,
+    raw_text: String,
+    chunk_index: u32,
+    config: &ChunkConfig,
+) -> Chunk {
+    let links = extract_wikilinks(&raw_text);
+    let content = if config.resolve_wikilinks {
+        resolve_wikilinks_in_text(&raw_text)
+    } else {
+        raw_text.clone()
+    };
+    Chunk {
+        note_path: note_path.to_string(),
+        breadcrumb,
+        content,
+        raw_content: raw_text,
+        chunk_index,
+        links,
+    }
+}
+
+pub fn chunk_markdown(note_path: &str, markdown: &str, config: &ChunkConfig) -> Vec<Chunk> {
+    let sections = parse_sections(markdown);
+
+    // Collect raw sections: (breadcrumb, body_text)
+    let mut raw_sections: Vec<(String, String)> = Vec::new();
+
+    // Preamble: text before first heading
+    let preamble_end = sections
+        .first()
+        .map(|s| s.heading_range.start)
+        .unwrap_or(markdown.len());
+    let preamble = markdown[..preamble_end].trim();
+    if !preamble.is_empty() {
+        let text = extract_text(preamble);
+        let trimmed = text.trim().to_string();
+        if !trimmed.is_empty() {
+            raw_sections.push((note_path.to_string(), trimmed));
+        }
+    }
+
+    // Headed sections
+    let breadcrumbs = build_breadcrumbs(note_path, &sections);
+    let body_ranges = direct_body_ranges(&sections, markdown.len());
+
+    for (i, (start, end)) in body_ranges.iter().enumerate() {
+        let raw_body = markdown[*start..*end].trim();
+        if raw_body.is_empty() {
+            continue;
+        }
+        let text = extract_text(raw_body);
+        let trimmed = text.trim().to_string();
+        if !trimmed.is_empty() {
+            raw_sections.push((breadcrumbs[i].clone(), trimmed));
+        }
+    }
+
+    // Filter, split, and create chunks
     let mut chunks = Vec::new();
     let mut chunk_index: u32 = 0;
 
     for (breadcrumb, raw_text) in raw_sections {
-        // Skip noise chunks (e.g. link-only "Related documents" sections)
-        if config.min_content_chars > 0 && prose_char_count(&raw_text) < config.min_content_chars {
+        if should_skip_section(&raw_text, config) {
             continue;
         }
 
         if raw_text.len() <= config.max_chars {
-            let links = extract_wikilinks(&raw_text);
-            let content = if config.resolve_wikilinks {
-                resolve_wikilinks_in_text(&raw_text)
-            } else {
-                raw_text.clone()
-            };
-            chunks.push(Chunk {
-                note_path: note_path.to_string(),
+            chunks.push(make_chunk(
+                note_path,
                 breadcrumb,
-                content,
-                raw_content: raw_text,
+                raw_text,
                 chunk_index,
-                links,
-            });
+                config,
+            ));
             chunk_index += 1;
         } else {
             let sub_chunks = split_large_section(&raw_text, config);
             for sub in sub_chunks {
-                let links = extract_wikilinks(&sub);
-                let content = if config.resolve_wikilinks {
-                    resolve_wikilinks_in_text(&sub)
-                } else {
-                    sub.clone()
-                };
-                chunks.push(Chunk {
-                    note_path: note_path.to_string(),
-                    breadcrumb: breadcrumb.clone(),
-                    content,
-                    raw_content: sub,
+                chunks.push(make_chunk(
+                    note_path,
+                    breadcrumb.clone(),
+                    sub,
                     chunk_index,
-                    links,
-                });
+                    config,
+                ));
                 chunk_index += 1;
             }
         }
     }
 
     chunks
-}
-
-/// Internal: flush a raw section (breadcrumb + text) without splitting.
-fn flush_section(
-    note_path: &str,
-    heading_stack: &[(u8, String)],
-    text: &str,
-    sections: &mut Vec<(String, String)>,
-) {
-    let trimmed = text.trim();
-    if trimmed.is_empty() {
-        return;
-    }
-
-    let breadcrumb = if heading_stack.is_empty() {
-        note_path.to_string()
-    } else {
-        let path: Vec<&str> = heading_stack.iter().map(|(_, h)| h.as_str()).collect();
-        format!("{} > {}", note_path, path.join(" > "))
-    };
-
-    sections.push((breadcrumb, trimmed.to_string()));
 }
 
 /// Split a large text into chunks respecting paragraph boundaries and code blocks.
@@ -190,30 +211,6 @@ fn split_preserving_code_blocks(text: &str) -> Vec<String> {
     }
 
     segments
-}
-
-/// Count non-whitespace "prose" characters remaining after stripping wikilinks
-/// and list markers. Used to detect link-only chunks that carry no semantic value.
-fn prose_char_count(raw: &str) -> usize {
-    // Strip wikilinks: [[target]] and [[target|alias]]
-    let without_links = crate::wikilinks::WIKILINK_RE.replace_all(raw, "");
-    without_links
-        .lines()
-        .map(|line| {
-            // Strip list markers: "- ", "* ", "1. ", "2) " etc.
-            let trimmed = line.trim_start();
-            let after_marker = trimmed
-                .strip_prefix("- ")
-                .or_else(|| trimmed.strip_prefix("* "))
-                .or_else(|| {
-                    // Numbered lists: "1. " or "1) "
-                    let rest = trimmed.trim_start_matches(|c: char| c.is_ascii_digit());
-                    rest.strip_prefix(". ").or_else(|| rest.strip_prefix(") "))
-                })
-                .unwrap_or(trimmed);
-            after_marker.chars().filter(|c| !c.is_whitespace()).count()
-        })
-        .sum()
 }
 
 pub fn heading_level_to_u8(level: HeadingLevel) -> u8 {
@@ -479,39 +476,6 @@ Body text
     // --- Link-only chunk filtering ---
 
     #[test]
-    fn prose_char_count_link_only_list() {
-        let raw = "- [[Topic A]]\n- [[Topic B and more]]\n- [[Topic C]]";
-        assert!(
-            prose_char_count(raw) < 10,
-            "link-only list should have near-zero prose"
-        );
-    }
-
-    #[test]
-    fn prose_char_count_mixed_prose_and_links() {
-        let raw = "Lorem ipsum dolor sit amet, consectetur adipiscing elit sed do ([[Some Topic|eiusmod]]).";
-        assert!(
-            prose_char_count(raw) > 50,
-            "prose with links should count the surrounding text"
-        );
-    }
-
-    #[test]
-    fn prose_char_count_numbered_list_of_links() {
-        let raw = "1. [[Note A]]\n2. [[Note B]]\n3. [[Note C]]";
-        assert!(prose_char_count(raw) < 10);
-    }
-
-    #[test]
-    fn prose_char_count_plain_text() {
-        let raw = "This is a normal paragraph with no links at all.";
-        assert_eq!(
-            prose_char_count(raw),
-            raw.chars().filter(|c| !c.is_whitespace()).count()
-        );
-    }
-
-    #[test]
     fn filter_drops_link_only_section() {
         let md = "\
 # Workplace
@@ -579,6 +543,100 @@ Another section with meaningful content that should be indexed.
         };
         let chunks = chunk_markdown("note.md", md, &config);
         assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].chunk_index, 0);
+        assert_eq!(chunks[1].chunk_index, 1);
+    }
+
+    // --- Integration tests: changelog and boilerplate filtering ---
+
+    #[test]
+    fn changelog_section_filtered() {
+        let md = "\
+# System zarządzania
+
+System priorytetyzacji to automatyczna metoda oceny ważności zadań.
+Przejawia się rankingowaniem działań według wartości biznesowej.
+
+## Historia zmian
+- 2026-02-06: Utworzenie dokumentu
+- 2026-02-14 00:15: aktualizacja po spotkaniu zespołu
+";
+        let chunks = chunk_markdown("system.md", md, &ChunkConfig::default());
+        assert_eq!(chunks.len(), 1, "changelog section should be filtered out");
+        assert!(chunks[0].content.contains("System priorytetyzacji"));
+        assert_eq!(chunks[0].chunk_index, 0);
+    }
+
+    #[test]
+    fn changelog_with_wikilinked_dates_filtered() {
+        let md = "\
+# Temat
+
+Treść merytoryczna z wystarczającą ilością tekstu do embedowania.
+
+## Historia zmian
+- [[2026-01-31]]: pierwsze rozpoznanie tej części
+- [[2026-02-06]]: aktualizacja po spotkaniu
+";
+        let chunks = chunk_markdown("temat.md", md, &ChunkConfig::default());
+        assert_eq!(chunks.len(), 1);
+        assert!(!chunks[0].content.contains("2026"));
+    }
+
+    #[test]
+    fn links_with_comments_kept() {
+        let md = "\
+# Moduł systemu
+
+Opis modułu w kontekście architektury. To jest ważny moduł odpowiedzialny za walidację.
+
+## Powiązania
+- [[Zespół]] - delegacja uprawnień, źródło decyzji o poziomie dostępu
+- [[Projekt Alpha]] - historia migracji bez testów regresji, bez dokumentacji
+- [[Wzorzec legacy systems]] - akceptowanie architektury gdzie nasze wymogi nie są priorytetem
+";
+        let chunks = chunk_markdown("modul.md", md, &ChunkConfig::default());
+        assert_eq!(
+            chunks.len(),
+            2,
+            "Powiazania with prose comments should be kept"
+        );
+        assert!(chunks[1].content.contains("delegacja uprawnień"));
+    }
+
+    #[test]
+    fn full_template_document_filters_boilerplate() {
+        let md = "\
+# Proces skalowania
+
+Proces skalowania to automatyczna reakcja na wzrost obciążenia systemu.
+Przejawia się uruchamianiem dodatkowych instancji aplikacji.
+
+## Jak się przejawia
+
+Monitorowanie metryk wydajności, alokacja zasobów, balansowanie obciążenia.
+
+## Powiązane dokumenty
+- [[Infrastruktura]]
+- [[Projekt Alpha]]
+- [[Wzorzec microservices]]
+
+## Historia zmian
+- 2026-02-06: Utworzenie dokumentu
+- 2026-02-14: Rozbudowa po przeglądzie architektury
+";
+        let chunks = chunk_markdown("proces.md", md, &ChunkConfig::default());
+        assert_eq!(
+            chunks.len(),
+            2,
+            "Only 2 content sections should survive: intro + Jak sie przejawia"
+        );
+        assert!(chunks[0].content.contains("Proces skalowania"));
+        assert!(
+            chunks[1]
+                .content
+                .contains("Monitorowanie metryk wydajności")
+        );
         assert_eq!(chunks[0].chunk_index, 0);
         assert_eq!(chunks[1].chunk_index, 1);
     }

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -1,6 +1,7 @@
 mod chunker;
 mod frontmatter;
 pub mod path_validation;
+pub(crate) mod section_filter;
 pub mod sections;
 pub mod transforms;
 pub mod types;

--- a/crates/parser/src/section_filter.rs
+++ b/crates/parser/src/section_filter.rs
@@ -1,0 +1,251 @@
+/// Strip list markers from the start of a line.
+/// Returns the remainder after the marker, or the original line if no marker found.
+#[allow(dead_code)] // Used in later tasks
+pub(crate) fn strip_list_marker(line: &str) -> &str {
+    // First trim leading whitespace (to match original behavior in chunker.rs:204)
+    let trimmed = line.trim_start();
+
+    // Try unordered list markers: "- " or "* "
+    if let Some(rest) = trimmed
+        .strip_prefix("- ")
+        .or_else(|| trimmed.strip_prefix("* "))
+    {
+        return rest;
+    }
+
+    // Try numbered list markers: "1. " or "1) "
+    let after_digits = trimmed.trim_start_matches(|c: char| c.is_ascii_digit());
+    if after_digits.len() < trimmed.len() {
+        // We found at least one digit
+        if let Some(rest) = after_digits
+            .strip_prefix(". ")
+            .or_else(|| after_digits.strip_prefix(") "))
+        {
+            return rest;
+        }
+    }
+
+    // No marker found, return trimmed line
+    trimmed
+}
+
+/// Count non-whitespace "prose" characters remaining after stripping wikilinks
+/// and list markers. Used to detect link-only chunks that carry no semantic value.
+pub(crate) fn prose_char_count(raw: &str) -> usize {
+    let without_links = crate::wikilinks::WIKILINK_RE.replace_all(raw, "");
+    without_links
+        .lines()
+        .map(|line| {
+            let after_marker = strip_list_marker(line.trim_start());
+            after_marker.chars().filter(|c| !c.is_whitespace()).count()
+        })
+        .sum()
+}
+
+use std::sync::LazyLock;
+
+#[allow(dead_code)] // Used in later tasks
+static CHANGELOG_DATE_RE: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r"^(\[\[)?\d{4}-\d{2}-\d{2}(\]\])?").unwrap());
+
+/// Detect changelog-like sections: >=80% of non-empty lines (after stripping
+/// list markers) start with a date pattern (bare or wikilinked YYYY-MM-DD).
+#[allow(dead_code)] // Used in later tasks
+pub(crate) fn is_changelog_section(raw: &str) -> bool {
+    let lines: Vec<&str> = raw
+        .lines()
+        .map(|l| strip_list_marker(l.trim_start()))
+        .filter(|l| !l.is_empty())
+        .collect();
+    if lines.is_empty() {
+        return false;
+    }
+    let date_count = lines
+        .iter()
+        .filter(|l| CHANGELOG_DATE_RE.is_match(l))
+        .count();
+    date_count as f32 / lines.len() as f32 >= 0.8
+}
+
+use crate::types::ChunkConfig;
+
+/// Returns true if a section should be excluded from chunking.
+/// Checks: (1) low prose content (link-only sections), (2) changelog patterns.
+#[allow(dead_code)] // Used in later tasks
+pub(crate) fn should_skip_section(raw: &str, config: &ChunkConfig) -> bool {
+    if config.min_content_chars > 0 && prose_char_count(raw) < config.min_content_chars {
+        return true;
+    }
+    is_changelog_section(raw)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn strip_dash_marker() {
+        assert_eq!(strip_list_marker("- item text"), "item text");
+    }
+
+    #[test]
+    fn strip_star_marker() {
+        assert_eq!(strip_list_marker("* item text"), "item text");
+    }
+
+    #[test]
+    fn strip_numbered_dot_marker() {
+        assert_eq!(strip_list_marker("1. first item"), "first item");
+        assert_eq!(strip_list_marker("12. twelfth item"), "twelfth item");
+    }
+
+    #[test]
+    fn strip_numbered_paren_marker() {
+        assert_eq!(strip_list_marker("1) first item"), "first item");
+        assert_eq!(strip_list_marker("2) second item"), "second item");
+    }
+
+    #[test]
+    fn no_marker_returns_original() {
+        assert_eq!(strip_list_marker("plain text"), "plain text");
+        assert_eq!(strip_list_marker(""), "");
+    }
+
+    #[test]
+    fn dash_without_space_not_stripped() {
+        assert_eq!(strip_list_marker("-no space"), "-no space");
+    }
+
+    #[test]
+    fn strip_marker_with_leading_whitespace() {
+        assert_eq!(strip_list_marker("  - item text"), "item text");
+        assert_eq!(strip_list_marker("\t* item text"), "item text");
+    }
+
+    #[test]
+    fn prose_char_count_link_only_list() {
+        let raw = "- [[Rewolucja Doloriańska]]\n- [[Bled Przeklęty]]\n- [[Komuna Martinaise]]";
+        assert!(
+            prose_char_count(raw) < 10,
+            "link-only list should have near-zero prose"
+        );
+    }
+
+    #[test]
+    fn prose_char_count_mixed_prose_and_links() {
+        let raw = "Albowiem sprawa ta, przez ([[Duch Rewolucji|wieki]]) skryta w mrokach Bledy, wyłoniła się nagle z odmętów niczym okręt widmo.";
+        assert!(
+            prose_char_count(raw) > 50,
+            "prose with links should count the surrounding text"
+        );
+    }
+
+    #[test]
+    fn prose_char_count_numbered_list_of_links() {
+        let raw = "1. [[Towarzysze z portu]]\n2. [[Bled od północy]]\n3. [[Komitet Rewolucyjny]]";
+        assert!(prose_char_count(raw) < 10);
+    }
+
+    #[test]
+    fn prose_char_count_plain_text() {
+        let raw = "Oto wszak Revachol stoi zasię na skraju przepaści, a Bled zbliża się od północy nieodparcie.";
+        assert_eq!(
+            prose_char_count(raw),
+            raw.chars().filter(|c| !c.is_whitespace()).count()
+        );
+    }
+
+    #[test]
+    fn changelog_pure_date_lines() {
+        let raw = "- 2026-02-06: Akta sprawy otwarte, vide protokół\n- 2026-02-14 00:15: Zaktualizowane po odprawie à Martinaise";
+        assert!(is_changelog_section(raw));
+    }
+
+    #[test]
+    fn changelog_wikilinked_dates() {
+        let raw = "- [[2026-01-31]]: Pierwsza ekspedycja na le Pale\n- [[2026-02-06]]: Rewizja w porcie Revachol";
+        assert!(is_changelog_section(raw));
+    }
+
+    #[test]
+    fn changelog_single_date_line() {
+        let raw = "- 2026-02-06: Notatki z przesłuchania, na rozkaz porucznika Kitsuragi";
+        assert!(is_changelog_section(raw));
+    }
+
+    #[test]
+    fn changelog_mixed_dates_and_wikilink_dates() {
+        let raw = "- 2026-02-06: Otwarte\n- [[2026-01-31]]: Rekonesans, ничего nie znaleziono\n- 2026-02-14 00:15: Zaktualizowane";
+        assert!(is_changelog_section(raw));
+    }
+
+    #[test]
+    fn not_changelog_narrative_with_one_date() {
+        let raw = "2026-02-06 roku pękło coś w onéj skowanej pamięci detektywa.\nStał w zaułku Martinaise jak człek bez miana i bez przeszłości.\nTovarisch Kitsuragi rzekł cicho: ne teryaj golovu, Harrier.\nQuelque chose zamknęło się wówczas we wnętrzu i nie otworzyło zasię.";
+        assert!(!is_changelog_section(raw));
+    }
+
+    #[test]
+    fn not_changelog_prose_section() {
+        let raw = "Bled zstępuje na Revachol od północy, jeno skrywszy oblicze za mgłą niepamiętania.\nOficerowie RCM donoszą o anomaliach, gdyż granica Bledy przesunęła się zasię ku centrum.";
+        assert!(!is_changelog_section(raw));
+    }
+
+    #[test]
+    fn not_changelog_empty_section() {
+        assert!(!is_changelog_section(""));
+        assert!(!is_changelog_section("   \n  \n  "));
+    }
+
+    #[test]
+    fn not_changelog_links_with_comments() {
+        let raw = "- [[Measurehead]] - zawał ideologiczny, źródło przekonania że klasa est sans discipline\n- [[Joyce Messier]] - dzierży klucze do portu, levier politique nad związkiem";
+        assert!(!is_changelog_section(raw));
+    }
+
+    use crate::types::ChunkConfig;
+
+    #[test]
+    fn should_skip_link_only_section() {
+        let config = ChunkConfig::default(); // min_content_chars: 50
+        let raw = "- [[Rewolucja Doloriańska]]\n- [[Bled Przeklęty]]\n- [[Komuna Martinaise]]";
+        assert!(should_skip_section(raw, &config));
+    }
+
+    #[test]
+    fn should_skip_changelog_section() {
+        let config = ChunkConfig::default();
+        let raw =
+            "- 2026-02-06: Akta otwarte w Martinaise\n- 2026-02-14: Zaktualizowane po odprawie";
+        assert!(should_skip_section(raw, &config));
+    }
+
+    #[test]
+    fn should_keep_prose_section() {
+        let config = ChunkConfig::default();
+        let raw = "Bled zstępuje na Revachol od północy, jeno skrywszy oblicze za gęstą mgłą niepamiętania, albowiem kończy się czas Rewolucji.";
+        assert!(!should_skip_section(raw, &config));
+    }
+
+    #[test]
+    fn should_keep_links_with_prose_comments() {
+        let config = ChunkConfig::default();
+        let raw = "- [[Measurehead]] - zawał ideologiczny, źródło przekonania że klasa robotnicza est sans discipline i bez przyszłości\n- [[Joyce Messier]] - dzierży klucze do portu, levier politique над związkiem zawodowym marynarzy";
+        assert!(!should_skip_section(raw, &config));
+    }
+
+    #[test]
+    fn should_skip_disabled_when_min_chars_zero() {
+        let config = ChunkConfig {
+            min_content_chars: 0,
+            ..ChunkConfig::default()
+        };
+        // Link-only section passes because prose filter is disabled
+        // but changelog filter still applies
+        let changelog = "- 2026-02-06: Akta otwarte w Martinaise, vide protokół";
+        assert!(should_skip_section(changelog, &config));
+
+        let links = "- [[Rewolucja]]\n- [[Bled]]";
+        assert!(!should_skip_section(links, &config));
+    }
+}

--- a/crates/web/tests/integration.rs
+++ b/crates/web/tests/integration.rs
@@ -136,7 +136,7 @@ async fn test_app_state() -> Arc<AppState> {
 
 /// Helper to create test router (duplicates logic from serve() function)
 fn test_router(state: Arc<AppState>) -> Router {
-    use axum::routing::{get, post, put};
+    use axum::routing::{get, post};
 
     Router::new()
         .route("/api/search", get(kajet_web::api_search))


### PR DESCRIPTION
## Summary

- Created `section_filter` module with changelog detection heuristic (≥80% lines start with YYYY-MM-DD dates)
- Migrated chunker from manual heading walker to shared `parse_sections()` primitive, eliminating code duplication
- Boilerplate sections (changelog, link-only) now excluded from vector index while remaining in full_text for FTS
- Bumped schema version to 4 to trigger automatic reindex with new filtering logic

## Test Plan

- [x] All 517 workspace tests pass
- [x] Unit tests for `strip_list_marker`, `prose_char_count`, `is_changelog_section`, `should_skip_section`
- [x] Integration tests verify changelog/boilerplate filtering with anonymized test fixtures
- [x] Pre-commit hooks pass (clippy, fmt, typos)
- [ ] Verify improved `find_similar` results on therapeutic journaling vault after reindex

🤖 Generated with [Claude Code](https://claude.com/claude-code)