### PR TITLE
fix(mcp): UTF-8 safe search preview + panic hook

### DIFF
--- a/crates/core/src/search.rs
+++ b/crates/core/src/search.rs
@@ -93,7 +93,10 @@ impl SearchEngine {
     /// Hybrid search: vector similarity + FTS, merged by weighted scoring.
     #[tracing::instrument(level = "debug", skip(self), fields(vector_hits, fts_hits))]
     pub async fn hybrid_search(&self, query: &str, limit: usize) -> Result<Vec<SearchResult>> {
+        let overall_start = std::time::Instant::now();
         let fetch_limit = limit * 2;
+
+        tracing::debug!(query_len = query.len(), limit, "hybrid_search start");
 
         // Run vector and FTS searches in parallel
         let (vector_results, fts_results) = tokio::join!(
@@ -122,6 +125,8 @@ impl SearchEngine {
         tracing::debug!(
             score_min = merged.last().map(|r| r.score),
             score_max = merged.first().map(|r| r.score),
+            elapsed_ms = overall_start.elapsed().as_millis() as u64,
+            results = merged.len().min(limit),
             "hybrid merge complete"
         );
 
@@ -131,9 +136,16 @@ impl SearchEngine {
     /// Pure vector similarity search.
     #[tracing::instrument(level = "debug", skip(self))]
     pub async fn vector_search(&self, query: &str, limit: usize) -> Result<Vec<SearchResult>> {
+        let embed_start = std::time::Instant::now();
         let embedder = self.embedder.read().await.clone();
         let prefixed = apply_prefix(&self.query_prefix, query);
         let query_emb = embedder.embed(vec![prefixed.as_str()]).await?;
+
+        tracing::debug!(
+            embed_ms = embed_start.elapsed().as_millis() as u64,
+            "query embedded"
+        );
+
         let hits = self.store.search(&query_emb[0], limit).await?;
 
         Ok(hits

--- a/crates/mcp/src/handlers/search.rs
+++ b/crates/mcp/src/handlers/search.rs
@@ -62,6 +62,7 @@ impl crate::KajetMcp {
                     mode = mode.as_str(),
                     limit,
                     results,
+                    response_bytes = summary.len(),
                     elapsed_ms = start.elapsed().as_millis() as u64,
                     "MCP search"
                 );

--- a/crates/mcp/src/use_cases/search.rs
+++ b/crates/mcp/src/use_cases/search.rs
@@ -60,11 +60,7 @@ pub(crate) async fn execute_search(
             let result_summaries: Vec<SearchResultSummary> = results
                 .iter()
                 .map(|r| {
-                    let preview = if r.content.len() > 150 {
-                        format!("{}...", &r.content[..150])
-                    } else {
-                        r.content.clone()
-                    };
+                    let preview = kajet_core::text_utils::truncate_with_ellipsis(&r.content, 150);
                     SearchResultSummary {
                         note_path: r.note_path.clone(),
                         breadcrumb: r.breadcrumb.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,24 @@ struct Cli {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Log panics through tracing so they appear in kajet.log
+    let default_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let payload = if let Some(s) = info.payload().downcast_ref::<&str>() {
+            (*s).to_string()
+        } else if let Some(s) = info.payload().downcast_ref::<String>() {
+            s.clone()
+        } else {
+            "unknown panic".to_string()
+        };
+        let location = info
+            .location()
+            .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
+            .unwrap_or_default();
+        tracing::error!(payload = %payload, location = %location, "PANIC in tokio task");
+        default_hook(info);
+    }));
+
     let cli = Cli::parse();
 
     let vault_path = std::path::Path::new(&cli.vault);


### PR DESCRIPTION
## Summary
- **Root cause fix**: `&content[..150]` panicked on Polish characters (ą, ę, ś) when byte 150 fell inside a multi-byte char — tokio task died silently and MCP responses never returned, causing indefinite hangs in Claude Desktop
- **Panic hook**: Future panics now appear in `kajet.log` as ERROR instead of being silently swallowed by tokio
- **Search instrumentation**: DEBUG-level timing for embedding and hybrid_search, `response_bytes` in MCP search INFO log

## Test plan
- [x] `cargo nextest run -p kajet-mcp -E 'test(format_results)'` — all 6 pass
- [x] Pre-commit hooks pass (clippy, fmt)
- [ ] Manual: search with Polish content in vault via Claude Desktop — response returns immediately
- [ ] Manual: verify panic hook by checking `kajet.log` after intentional panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)