### PR TITLE
feat(parser): strip frontmatter from documents.full_text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3696,7 +3696,7 @@ dependencies = [
 
 [[package]]
 name = "kajet-backend"
-version = "0.2.3"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -3723,7 +3723,7 @@ dependencies = [
 
 [[package]]
 name = "kajet-core"
-version = "0.2.3"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3745,7 +3745,7 @@ dependencies = [
 
 [[package]]
 name = "kajet-indexer"
-version = "0.2.3"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3763,7 +3763,7 @@ dependencies = [
 
 [[package]]
 name = "kajet-mcp"
-version = "0.2.3"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3783,7 +3783,7 @@ dependencies = [
 
 [[package]]
 name = "kajet-parser"
-version = "0.2.3"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3801,7 +3801,7 @@ dependencies = [
 
 [[package]]
 name = "kajet-remote"
-version = "0.2.3"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3815,7 +3815,7 @@ dependencies = [
 
 [[package]]
 name = "kajet-web"
-version = "0.2.3"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3841,7 +3841,7 @@ dependencies = [
 
 [[package]]
 name = "kajet-writer"
-version = "0.2.3"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/crates/backend/src/metadata.rs
+++ b/crates/backend/src/metadata.rs
@@ -6,7 +6,8 @@ use std::path::Path;
 /// Version 2: Added chunk_index column to search results
 /// Version 3: Fixed chunk_index type from UInt32 to Int64
 /// Version 4: Chunker refactored — changelog/boilerplate sections excluded from index
-pub const CURRENT_SCHEMA_VERSION: u32 = 4;
+/// Version 5: full_text stores body without frontmatter (frontmatter metadata in dedicated fields)
+pub const CURRENT_SCHEMA_VERSION: u32 = 5;
 
 fn default_embedding_backend() -> String {
     "candle".to_string()

--- a/crates/parser/src/lib.rs
+++ b/crates/parser/src/lib.rs
@@ -54,7 +54,7 @@ pub fn parse_document_with_date_fields(
 
     let doc = ParsedDocument {
         source_file: rel_path.to_string(),
-        full_text: content.to_string(),
+        full_text: body.to_string(),
         title,
         tags,
         frontmatter_created,
@@ -123,7 +123,8 @@ mod tests {
     fn parse_document_full_text_preserved() {
         let md = "---\ntags: [test]\n---\n# Title\n\nBody";
         let (doc, _) = parse_document("note.md", md, &default_config());
-        assert_eq!(doc.full_text, md);
+        // full_text should contain body without frontmatter
+        assert_eq!(doc.full_text, "\n# Title\n\nBody");
         assert_eq!(doc.source_file, "note.md");
     }
 


### PR DESCRIPTION
## Summary

- `documents.full_text` now stores body without YAML frontmatter block — metadata (tags, title, dates) is already extracted to dedicated `ParsedDocument` fields, so no data loss
- Fixes FTS snippets starting with raw `---\ntags:...\n---` YAML noise in hybrid search (MCP) results
- Fixes examine tool and analytics showing/counting YAML content
- Bumps schema version to 5 to trigger automatic reindex on next run

## Test Plan

- [x] `cargo nextest run -p kajet-parser` — 191/191 pass
- [x] `cargo nextest run --workspace` — 517/517 pass
- [x] `cargo clippy --workspace -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)